### PR TITLE
Added hit ratio statistics to lmt

### DIFF
--- a/liblmt/ost.h
+++ b/liblmt/ost.h
@@ -28,8 +28,10 @@ int lmt_ost_string_v2 (pctx_t ctx, char *s, int len);
 
 int lmt_ost_decode_v2 (const char *s, char **ossnamep,
                         float *pct_cpup, float *pct_memp, List *ostinfop);
+
 int lmt_ost_decode_v2_ostinfo (const char *s, char **ostnamep,
-                        uint64_t *read_bytesp, uint64_t *write_bytesp,
+                        uint64_t *read_bytesp, uint64_t *hitsp,
+                        uint64_t *accessp, uint64_t *write_bytesp,
                         uint64_t *kbytes_freep, uint64_t *kbytes_totalp,
                         uint64_t *inodes_freep, uint64_t *inodes_totalp,
                         uint64_t *iopsp, uint64_t *num_exportsp,

--- a/liblmtdb/lmtdb.c
+++ b/liblmtdb/lmtdb.c
@@ -158,9 +158,11 @@ _insert_ostinfo (char *ossname, float pct_cpu, float pct_mem, char *s)
     uint64_t iops, num_exports;
     uint64_t lock_count, grant_rate, cancel_rate;
     uint64_t connect, reconnect;
+    uint64_t hits, access;
     char *recov_status = NULL;
 
-    if (lmt_ost_decode_v2_ostinfo (s, &ostname, &read_bytes, &write_bytes,
+    if (lmt_ost_decode_v2_ostinfo (s, &ostname, &read_bytes, 
+                                   &hits, &access, &write_bytes,
                                    &kbytes_free, &kbytes_total,
                                    &inodes_free, &inodes_total, &iops,
                                    &num_exports, &lock_count, &grant_rate,

--- a/lmt.spec
+++ b/lmt.spec
@@ -1,5 +1,5 @@
 Name: lmt
-Version: 3.1.2
+Version: 3.1.3
 Release: 1
 
 # TODO: lmt-utils subpackage for ltop (once ltop can read proc directly)

--- a/test/tparse.c
+++ b/test/tparse.c
@@ -186,6 +186,7 @@ _parse_ost_v2 (const char *s)
     uint64_t iops, num_exports;
     uint64_t lock_count, grant_rate, cancel_rate;
     uint64_t connect, reconnect;
+    uint64_t hits, access;
     List ostinfo = NULL;
     ListIterator itr = NULL;
     char *osi;
@@ -195,7 +196,8 @@ _parse_ost_v2 (const char *s)
     if (!(itr = list_iterator_create (ostinfo)))
         goto done;
     while ((osi = list_next (itr))) {
-        if (lmt_ost_decode_v2_ostinfo (osi, &ostname, &read_bytes, &write_bytes,
+        if (lmt_ost_decode_v2_ostinfo (osi, &ostname, &read_bytes, 
+                                       &hits, &access, &write_bytes,
                                        &kbytes_free, &kbytes_total,
                                        &inodes_free, &inodes_total, &iops,
                                        &num_exports, &lock_count, &grant_rate,


### PR DESCRIPTION
The ltop display has been formatted to display the read cache hit ratio per ost. The hit ratio is calculated by dividing the cache_hit variable by cache_access taken from within the /proc/fs/lustre/obdfilter/<OST>/stats file using the liblmt/ost.c library functions. Room was made for the 4 characters needed for this column by deleting two extra spaces from OSS name collumn, one from the Locks column, and 1 from the CR (connection rate) column.
