### PR TITLE
Add libm to autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,11 @@ AC_C_BIGENDIAN
 AC_C_CONST
 
 ##
+# Checks for standard libraries
+##
+AC_CHECK_LIB(m, cos)
+
+##
 # Checks for library functions
 ##
 AC_CHECK_FUNCS( \


### PR DESCRIPTION
While building on RHEL5, I noticed libm wasn't being used when testing for LUA.  
