### PR TITLE
Fix version number in lmt.spec

### DIFF
--- a/lmt.spec
+++ b/lmt.spec
@@ -1,5 +1,5 @@
 Name: lmt
-Version: 3.1.5
+Version: 3.1.6
 Release: 1
 
 # TODO: lmt-utils subpackage for ltop (once ltop can read proc directly)


### PR DESCRIPTION
The version number in lmt.spec does not match the current version number
for LMT.  It has been changed to 3.1.6 to match everything else.
