### PR TITLE
Fixed head and tail operations on OSS_DATA table

### DIFF
--- a/scripts/lmtsh.in
+++ b/scripts/lmtsh.in
@@ -302,6 +302,9 @@ while ( defined (my $cmd = $term->readline($prompt)) ) {
 	
 	if ($table eq "TIMESTAMP_INFO") {
 	    $q = "select * from TIMESTAMP_INFO order by TIMESTAMP $order limit $n";
+	} elsif ($table eq "OSS_DATA") {
+	    $q = "select x1.*,TIMESTAMP from $table as x1,TIMESTAMP_INFO where x1.TS_ID=TIMESTAMP_INFO.TS_ID " .
+		"order by TIMESTAMP $order,OSS_ID $order limit $n";
 	} elsif ($table eq "OST_DATA") {
 	    $q = "select x1.*,TIMESTAMP from $table as x1,TIMESTAMP_INFO where x1.TS_ID=TIMESTAMP_INFO.TS_ID " .
 		"order by TIMESTAMP $order,OST_ID $order limit $n";


### PR DESCRIPTION
Fixed head and tail operations on the OSS_DATA table.  Added a condition
to check whether the table is OSS_DATA when the operation is head or
tail.  If so, it sets up the query to get the first or last n rows of
the table.  Tested that head and tail operations work on OSS_DATA table.
Also tested that head and tail operations work on all tables which they
worked on before the change.

Closes #18
