### PR TITLE
Fix compilation against Lua 5.2.

### DIFF
--- a/liblmt/lmtconf.c
+++ b/liblmt/lmtconf.c
@@ -198,7 +198,7 @@ lmt_conf_init (int vopt, char *path)
             path = PATH_LMTCONF; /* missing default config file is not fatal */
     }
     if (path) {
-        L = lua_open ();
+        L = luaL_newstate();
         luaL_openlibs(L);
 
         if (luaL_loadfile (L, path) || lua_pcall (L, 0, 0, 0)) {

--- a/lmt.spec.in
+++ b/lmt.spec.in
@@ -14,7 +14,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: mysql, mysql-devel
 BuildRequires: cerebro >= 1.3-5
 BuildRequires: ncurses-devel
-BuildRequires: lua-devel
+BuildRequires: lua-devel >= 5.1
 #%define __spec_install_post /usr/lib/rpm/brp-compress || :
 %define debug_package %{nil}
 


### PR DESCRIPTION
Lua 5.1 replaced the function lua_open with a preprocessor macro which
called luaL_newstate.  Lua 5.2 then removed lua_open entirely.  Thus,
LMT won't build against Lua 5.2.  This change replaces the call to
lua_open() with a call to luaL_newstate(), and since that function only
exists in Lua >= 5.1, a minimum version number of 5.1 was added to the
spec file BuildRequires.
