### PR TITLE
Fix buffer overflow, Add MDT detail sub-window

### DIFF
--- a/liblmt/common.h
+++ b/liblmt/common.h
@@ -1,6 +1,6 @@
 
 
-#define RECOVERY_STR_SIZE   32
+#define RECOVERY_STR_SIZE   64
 
 int
 get_recovstr (pctx_t ctx, char *name, char *s, int len);

--- a/liblmt/ost.c
+++ b/liblmt/ost.c
@@ -96,7 +96,7 @@ _get_oststring_v2 (pctx_t ctx, char *name, char *s, int len)
     uint64_t filesfree, filestotal;
     uint64_t kbytesfree, kbytestotal;
     uint64_t read_bytes, write_bytes;
-    uint64_t iops, num_exports;
+    uint64_t iops=0, num_exports;
     uint64_t lock_count, grant_rate, cancel_rate;
     uint64_t connect, reconnect;
     hash_t stats_hash = NULL;

--- a/utils/ltop.1.in
+++ b/utils/ltop.1.in
@@ -24,6 +24,38 @@ Log raw data from the session to FILE, so it can be played back with \fI\-p\fR.
 .I "-p,--play FILE"
 Play back raw data from FILE recorded with \fI\-r\fR or with the
 interactive \fIR\fR command.
+.SH "MDT FIELD DESCRIPTIONS"
+.TP
+\fIMDT\fR
+The mdt index, in hex.  In the compressed view (c below), the number of MDT's
+on the MDS is displayed in parenthesis.
+.TP
+\fIMDS\fR
+The MDS hostname.
+.TP
+\fIOpen\fR
+The number of file opens per second.
+.TP
+\fIClose\fR
+The number of file closes per second.
+.TP
+\fIGetattr\fR
+The number of file or directory getattrs per second.
+.TP
+\fISetattr\fR
+The number of file or directory setattrs per second.
+.TP
+\fIUnlink\fR
+The number of file unlinks per second.
+.TP
+\fIMkdir\fR
+The number of mkdirs per second.
+.TP
+\fIRmdir\fR
+The number of rmdirs per second.
+.TP
+\fIRename\fR
+The number of files or directories renamed per second.
 .SH "OST FIELD DESCRIPTIONS"
 .TP
 \fIOST\fR
@@ -66,14 +98,15 @@ The lock grant rate.
 \fILCR\fR
 The lock cancellation rate.
 .TP
-\fI%cpu
-The percentage of cpu in use on the OSS.
-.TP
-\fI%mem
-The percentage of memory in use on the OSS.
-.TP
 \fI%spc
 The percentage of OST storage space in use.
+.SH "COMMON FIELD DESCRIPTIONS"
+.TP
+\fI%cpu
+The percentage of cpu in use on the server.
+.TP
+\fI%mem
+The percentage of memory in use on the server.
 .SH "INTERACTIVE COMMANDS"
 .B ltop
 responds to the following single character commands interactively:
@@ -84,61 +117,89 @@ Terminate the
 program.
 .TP
 \fIPageDown\fR
-Page down through OST information if it won't fit on screen.
+Page down through target information if it won't fit on screen.
 .TP
 \fIPageUp\fR
-Page up through OST information if it won't fit on screen.
+Page up through target information if it won't fit on screen.
 .TP
 \fIc\fR
-Toggle compressed OST view.  The default mode is to display one line per OST.
-In compressed mode, one line per OSS is displayed.  Numerical data is summed
-in the OSS view except for the export count where the minimum export count
-of any OST is displayed.  Also if any of the OST's is in recovery, recovery
-information for that OST will be shown in the OSS view.
+Toggle compressed target view.  The default mode is to display one line per
+target.  In compressed mode, one line per server is displayed.  Numerical data
+is summed in the server view except for the export count where the minimum
+export count of any target is displayed.  Also if any of the target's is in
+recovery, recovery information for that target will be shown in the server
+view.
 .TP
 \fI>\fR
-Sort OST/OSS view by the next field to the right, wrapping around at the end.
-Initially, entries are sorted by the leftmost field, OST index.
+Sort MDT/OST window by the next field to the right, wrapping around at the end.
+Initially, entries are sorted by the leftmost field, OST/MDT index.
 .TP
 \fI<\fR
-Sort OST/OSS view by the next field to the left, wrapping around at the end.
-Initially, entries are sorted by the leftmost field, OST index.
+Sort MDT/OST window by the next field to the left, wrapping around at the end.
+Initially, entries are sorted by the leftmost field, OST/MDT index.
+.TP
+\fIt\fR
+Sort by target index, ascending order.
 .TP
 \fIs\fR
-Sort by OSS name, ascending order.
+Sort by server name, ascending order.
 .TP
 \fIx\fR
 Sort by export count, ascending order.
 .TP
 \fIC\fR
-Sort by (re-)connect rate, descending order.
+Sort by (re-)connect rate, descending order (OST).
 .TP
 \fIr\fR
-Sort by read bandwidth, descending order.
+Sort by read bandwidth, descending order (OST).
 .TP
 \fIw\fR
-Sort by write bandwidth, descending order.
+Sort by write bandwidth, descending order (OST).
 .TP
 \fIi\fR
-Sort by IOPS, descending order.
+Sort by IOPS, descending order (OST).
 .TP
 \fIl\fR
-Sort by lock count, descending order.
+Sort by lock count, descending order (OST).
 .TP
 \fIg\fR
-Sort by lock grant rate, descending order.
+Sort by lock grant rate, descending order (OST).
 .TP
 \fIL\fR
-Sort by lock cancellation rate, descending order.
+Sort by lock cancellation rate, descending order (OST).
+.TP
+\fIo\fR
+Sort by file open rate, descending order (MDT).
+.TP
+\fIC\fR
+Sort by file close rate, descending order (MDT).
+.TP
+\fIg\fR
+Sort by getattr rate, descending order (MDT).
+.TP
+\fIS\fR
+Sort by setattr rate, descending order (MDT).
+.TP
+\fIU\fR
+Sort by file unlink rate, descending order (MDT).
+.TP
+\fIM\fR
+Sort by mkdir rate, descending order (MDT).
+.TP
+\fIr\fR
+Sort by rmdir rate, descending order (MDT).
+.TP
+\fIR\fR
+Sort by rename rate, descending order (MDT).
 .TP
 \fIu\fR
 Sort by percent cpu utilization, descending order.
 .TP
 \fIm\fR
-Sort by percent memory utilization , descending order.
+Sort by percent memory utilization, descending order.
 .TP
 \fIS\fR
-Sort by percent disk space utilization , descending order.
+Sort by percent disk space utilization, descending order (OST).
 .TP
 \fIDOWN\fR
 Move cursor down.

--- a/utils/ltop.c
+++ b/utils/ltop.c
@@ -69,10 +69,26 @@
 #define MAXHOSTNAMELEN 64
 #endif
 
+/* (Mostly) fields common to all targets. For use in generic
+ * sort/summarize/display code.  Exception is tag, which is set only
+ * for OSTs, but needs to be visible to generic loop code.
+ */
 typedef struct {
     char fsname[17];            /* file system name */
     char name[17];              /* target index (4 hex digits) */
-    char oscstate[2];           /* single char state (blank if unknown) */
+    char servername[MAXHOSTNAMELEN];/* oss or mds hostname */
+    time_t tgt_metric_timestamp; /* cerebro timestamp for metric (not osc) */
+    char recov_status[RECOVERY_STR_SIZE];   /* free form string representing */
+                                            /* recovery status */
+    char tgtstate[2];           /* single char state (blank if unknown), */
+                                /* from osc */
+    sample_t pct_cpu;
+    sample_t pct_mem;
+    int tag;                    /* display this target line underlined */
+} generic_target_t;
+
+typedef struct {
+    generic_target_t common;    /* information common to all targets */
     sample_t rbytes;            /* read bytes/sec */
     sample_t wbytes;            /* write bytes/sec */
     sample_t iops;              /* io operations (r/w) per second */
@@ -83,19 +99,12 @@ typedef struct {
     sample_t connect;           /* connect+reconnect per second */
     sample_t kbytes_free;       /* free space (kbytes) */
     sample_t kbytes_total;      /* total space (kbytes) */
-    sample_t pct_cpu;
-    sample_t pct_mem;
-    char recov_status[RECOVERY_STR_SIZE];      /* free form string representing recov status */
     time_t ost_metric_timestamp;/* cerebro timestamp for ost metric (not osc) */
     char ossname[MAXHOSTNAMELEN];/* oss hostname */
-    int tag;                    /* display this ost line underlined */
 } oststat_t;
 
 typedef struct {
-    char fsname[17];            /* file system name */
-    char name[17];              /* target index (4 hex digitis) */
-    char recov_status[RECOVERY_STR_SIZE];      /* free form string representing recov status */
-    char tgtstate[2];           /* single char state (blank if unknown) */
+    generic_target_t common;    /* information common to all targets */
     sample_t inodes_free;       /* free inode count */
     sample_t inodes_total;      /* total inode count */
     sample_t open;              /* open ops/sec */
@@ -109,9 +118,13 @@ typedef struct {
     sample_t statfs;            /* statfs ops/sec */
     sample_t rename;            /* rename ops/sec */
     sample_t getxattr;          /* getxattr ops/sec */
-    time_t mdt_metric_timestamp;/* cerebro timestamp for mdt metric */
-    char mdsname[MAXHOSTNAMELEN];/* mds hostname */
 } mdtstat_t;
+
+typedef struct {
+    ListCmpF fun;
+    char k;
+    char h[20];
+} sort_t;
 
 typedef struct {
     long p;                     /* file offset */
@@ -123,6 +136,14 @@ typedef struct {
     uint64_t num_ost;          /* number of OSTs */
 } fsstat_t;
 
+/* used by _update_display_target */
+typedef void (* _display_line_fn) (WINDOW *win, int line, void *o,
+                                  int stale_secs, time_t tnow);
+
+/* used by _summarize_target */
+typedef void (* _tgt_update_summary) (void *tgt_v, void *summary_v);
+typedef void * (* _copy_tgtstat) (void *src);
+
 static void _poll_cerebro (char *fs, List mdt_data, List ost_data,
                            int stale_secs, FILE *recf, time_t *tp);
 static void _play_file (char *fs, List mdt_data, List ost_data,
@@ -133,17 +154,28 @@ static char *_choose_fs (WINDOW *win, FILE *playf, int stale_secs);
 static void _update_display_top (WINDOW *win, char *fs, List mdt_data,
                                  List ost_data, int stale_secs, FILE *recf,
                                  FILE *playf, time_t tnow, int pause);
-static void _update_display_ost (WINDOW *win, List ost_data, int minost,
-                                 int selost, int stale_secs, time_t tnow,
-                                 int i);
+static void _update_display_hdr (WINDOW *win, int cols, sort_t colhdr[],
+                                 int selcol);
+static void _update_display_target (WINDOW *win, List target_data,
+                                    int mintarget, int seltarget,
+                                    int stale_secs, time_t tnow,
+                                 _display_line_fn fn);
+static void _update_display_ost (WINDOW *win, int line, void *o,
+                                 int stale_secs, time_t tnow);
+static void _update_display_mdt (WINDOW *win, int line, void *target,
+                                 int stale_secs, time_t tnow);
 static void _destroy_oststat (oststat_t *o);
 static int _fsmatch (char *name, char *fs);
 static void _destroy_mdtstat (mdtstat_t *m);
 static void _summarize_ost (List ost_data, List oss_data, time_t tnow,
                             int stale_secs);
+static void _summarize_mdt (List mdt_data, List mds_data, time_t tnow,
+                            int stale_secs);
 static void _clear_tags (List ost_data);
 static void _tag_nth_ost (List ost_data, int selost, List ost_data2);
-static void _sort_ostlist (List ost_data, time_t tnow, char k, int *ip);
+static void _sort_tgtlist (List tgt_data, time_t tnow,
+                           ListCmpF comparison_function);
+static int  _get_sort_index (char k, int sort_index, sort_t c[], int nc);
 static char *_find_first_fs (FILE *playf, int stale_secs);
 static List _find_all_fs (FILE *playf, int stale_secs);
 static void _record_file (FILE *f, time_t tnow, time_t trcv, char *node,
@@ -152,11 +184,39 @@ static int _rewind_file (FILE *f, List time_series, int count);
 static void _rewind_file_to (FILE *f, List time_series, time_t target);
 static void _list_empty_out (List l);
 
-/* Hardwired display geometry.  We also assume 80 chars wide.
+
+/* comparison functions needed to sort by different fields */
+/* generic */
+static int _cmp_tgtstat_byserver (void *p1, void *p2);
+static int _cmp_tgtstat_bytarget (void *p1, void *p2);
+static int _cmp_tgtstat_bycpu (void *p1, void *p2);
+static int _cmp_tgtstat_bymem (void *p1, void *p2);
+static int _cmp_tgtstat_noop (void *p1, void *p2);
+
+/* OST/OSS */
+static int _cmp_oststat_byexp (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_bylocks (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_bylgr (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_bylcr (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_byconn (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_byiops (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_byrbw (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_bywbw (oststat_t *o1, oststat_t *o2);
+static int _cmp_oststat_byspc (oststat_t *o1, oststat_t *o2);
+
+/* MDT/MDS */
+static int _cmp_mdtstat_byopen (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_byclose (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_bygetattr (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_bysetattr (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_byunlink (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_byrmdir (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_bymkdir (mdtstat_t *m1, mdtstat_t *m2);
+static int _cmp_mdtstat_byrename (mdtstat_t *m1, mdtstat_t *m2);
+
+/* Top of display fixed.  We also assume 80 chars wide.
  */
 #define TOPWIN_LINES    7       /* lines in topwin */
-#define OSTWIN_H_LINES  1       /* header lines in ostwin */
-#define HDRLINES    (TOPWIN_LINES + OSTWIN_H_LINES)
 
 #define OPTIONS "f:t:s:r:p:"
 #if HAVE_GETOPT_LONG
@@ -174,10 +234,48 @@ static const struct option longopts[] = {
 #endif
 
 /* N.B. This global is used ONLY for the purpose of allowing
- * _sort_ostlist () to pass the current time to its various sorting
- * functions.
+ * _sort_tgtlist () to pass the current time to its various sorting
+ * functions that operate on samples and must validate them.
  */
 static time_t sort_tnow = 0;
+
+/* The order of records in ost_col and mdt_col should match the order
+ * the corresponding columns are displayed, so that when the user
+ * enters > or < the new sort column is adjacent to the last one in
+ * the display.  See _get_sort_index().
+ */
+sort_t ost_col[] = {
+    { .fun = (ListCmpF)_cmp_tgtstat_bytarget,.k = 't',  .h = "%sOST"        },
+                         /* search no-op */
+    { .fun = (ListCmpF)_cmp_tgtstat_noop,    .k =  0,   .h = "%sS"          },
+    { .fun = (ListCmpF)_cmp_tgtstat_byserver,.k = 's',  .h = "       %sOSS" },
+    { .fun = (ListCmpF)_cmp_oststat_byexp,   .k = 'x',  .h = "  %sExp"      },
+    { .fun = (ListCmpF)_cmp_oststat_byconn,  .k = 'C',  .h = "  %sCR"       },
+    { .fun = (ListCmpF)_cmp_oststat_byrbw,   .k = 'r',  .h = "%srMB/s"      },
+    { .fun = (ListCmpF)_cmp_oststat_bywbw,   .k = 'w',  .h = "%swMB/s"      },
+    { .fun = (ListCmpF)_cmp_oststat_byiops,  .k = 'i',  .h = " %sIOPS"      },
+    { .fun = (ListCmpF)_cmp_oststat_bylocks, .k = 'l',  .h = "  %sLOCKS"    },
+    { .fun = (ListCmpF)_cmp_oststat_bylgr,   .k = 'g',  .h = " %sLGR"       },
+    { .fun = (ListCmpF)_cmp_oststat_bylcr,   .k = 'L',  .h = " %sLCR"       },
+    { .fun = (ListCmpF)_cmp_tgtstat_bycpu,   .k = 'u',  .h = "%s%%cpu"      },
+    { .fun = (ListCmpF)_cmp_tgtstat_bymem,   .k = 'm',  .h = "%s%%mem"      },
+    { .fun = (ListCmpF)_cmp_oststat_byspc,   .k = 'S',  .h = "%s%%spc"      },
+};
+
+sort_t mdt_col[] = {
+    { .fun = (ListCmpF)_cmp_tgtstat_bytarget, .k =  't', .h = "%sMDT "      },
+    { .fun = (ListCmpF)_cmp_tgtstat_byserver, .k =  's', .h = "        %sMDS"},
+    { .fun = (ListCmpF)_cmp_mdtstat_byopen,   .k =  'o', .h = " %sOpen"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_byclose,  .k =  'C', .h = "%sClose"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_bygetattr,.k =  'g', .h = "%sGetAt"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_bysetattr,.k =  'S', .h = "%sSetAt"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_byunlink, .k =  'U', .h = "%sUnlnk"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_bymkdir,  .k =  'M', .h = "%sMkdir"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_byrmdir,  .k =  'r', .h = "%sRmdir"      },
+    { .fun = (ListCmpF)_cmp_mdtstat_byrename, .k =  'R', .h = "%sRenam"      },
+    { .fun = (ListCmpF)_cmp_tgtstat_bycpu,    .k =  'u', .h = " %s%%cpu"     },
+    { .fun = (ListCmpF)_cmp_tgtstat_bymem,    .k =  'm', .h = " %s%%mem"     },
+};
 
 static void
 usage (void)
@@ -193,20 +291,78 @@ usage (void)
     exit (1);
 }
 
+/* Decide how many lines to allocate to each portion of the window.
+ * 3 display geometries supported:
+ * A) topwin (or a subset) only
+ * B) topwin + OST header + some number of OST lines
+ * C) topwin + MDT and OST sets of (header, lines)
+ *
+ * mdtlines = 1 line for the header + rest for list of targets
+ * ostlines = 1 line for the header + rest for list of targets
+ */
+void
+size_windows(int total_size, int mdts, int osts,
+             int *mdtlines, int *ostlines)
+{
+    int headers = 2;    /* max lines occupied by MDT and OST headers */
+    int extra = total_size - (TOPWIN_LINES + mdts + osts + headers);
+
+    if (total_size <= TOPWIN_LINES) {
+        *mdtlines = 0;
+        *ostlines = 0;
+    } else {
+        if (mdts < 2 || (total_size < (TOPWIN_LINES + headers + 2))) {
+            // no need for per-mdt lines OR
+            // only big enough for topwin + small OST section
+            *mdtlines = 0;
+            *ostlines = total_size - TOPWIN_LINES;
+        } else {
+            /* big enough for both MDT and OST sections, and >1 MDT */
+            if (extra >= 0) { 
+                /* enough room to display everything */
+                *mdtlines = mdts+1;
+                *ostlines = osts+1;
+            } else {
+                /* OST and MDT section sizes proportional to target counts */
+                *mdtlines = mdts + 1 + ((float)extra*mdts) / ((float)mdts+osts);
+                *ostlines = total_size - (TOPWIN_LINES + *mdtlines);
+            }
+        }
+    }
+}
+
+void
+create_target_window(WINDOW **targetwin, int targetlines, int start_y)
+{
+    if (targetlines>=2) {
+        if (!(*targetwin = newwin (targetlines, 80, start_y, 0)))
+                err_exit ("error initializing subwindow");
+    } else {
+        *targetwin = NULL;
+    }
+}
+
 int
 main (int argc, char *argv[])
 {
     int c;
-    WINDOW *topwin, *ostwin;
+    WINDOW *topwin, *ostwin, *mdtwin;
+    int in_ostwin = 1;
     int ostcount, selost = -1, minost = 0;
-    int ostview = 1, resort = 0, recompute = 0, repoll = 0;
+    int mdtcount, selmdt = -1, minmdt = 0;
+    int mdtlines = 0, ostlines = 0;
+    int *mintgt = &minost, *seltgt = &selost, *tgtlines = &ostlines;
+    int *tgtcount = &ostcount;
+    int mdtview = 1, ostview = 1, resort = 0, recompute = 0, repoll = 0;
+    int *target_view = &ostview;
     char *fs = NULL, *newfs;
     int sopt = 0;
     int sample_period = 2; /* seconds */
     int stale_secs = 12; /* seconds */
     List ost_data = list_create ((ListDelF)_destroy_oststat);
-    List mdt_data = list_create ((ListDelF)_destroy_mdtstat);
     List oss_data = list_create ((ListDelF)_destroy_oststat);
+    List mdt_data = list_create ((ListDelF)_destroy_mdtstat);
+    List mds_data = list_create ((ListDelF)_destroy_oststat);
     List time_series = list_create ((ListDelF)free);
     time_t tcycle, last_sample = 0;
     char *recpath = "ltop.log";
@@ -214,7 +370,7 @@ main (int argc, char *argv[])
     FILE *playf = NULL;
     int pause = 0;
     int showhelp = 0;
-    int ost_fp = 0;
+    int mdt_fp = 0, ost_fp = 0;
 
     err_init (argv[0]);
     optind = 0;
@@ -255,7 +411,7 @@ main (int argc, char *argv[])
         msg_exit ("--record and --play cannot be used together");
 #if ! HAVE_CEREBRO_H
     if (!playf)
-	msg_exit ("ltop was not built with cerebro support, use -p option");
+        msg_exit ("ltop was not built with cerebro support, use -p option");
 #endif
     if (!fs)
         fs = _find_first_fs(playf, stale_secs);
@@ -272,20 +428,30 @@ main (int argc, char *argv[])
             msg_exit ("premature end of file on playback file");
     } else
         _poll_cerebro (fs, mdt_data, ost_data, stale_secs, recf, &tcycle);
-    _sort_ostlist (ost_data, tcycle, 0, &ost_fp);
+    _sort_tgtlist (ost_data, tcycle, ost_col[ost_fp].fun);
+    _sort_tgtlist (mdt_data, tcycle, mdt_col[mdt_fp].fun);
     assert (ostview);
+    assert (mdtview);
+    if ((mdtcount = list_count (mdt_data)) == 0)
+        msg_exit ("no MDT data found for file system `%s'", fs);
     if ((ostcount = list_count (ost_data)) == 0)
-        msg_exit ("no data found for file system `%s'", fs);
+        msg_exit ("no OST data found for file system `%s'", fs);
+
+    /* Initialize curses and create the windows.  more curses below. */
+    if (!(topwin = initscr ()))
+        err_exit ("error initializing parent window");
+
+    size_windows(LINES, mdtcount, ostcount, &mdtlines, &ostlines);
+
+    create_target_window(&mdtwin, mdtlines, TOPWIN_LINES);
+
+    create_target_window(&ostwin, ostlines, TOPWIN_LINES + mdtlines);
 
     /* Curses-fu:  keys will not be echoed, tty control sequences aren't
      * handled by tty driver, getch () times out and returns ERR after
      * sample_period seconds, multi-char keypad/arrow keys are handled.
      * Make cursor invisible.
      */
-    if (!(topwin = initscr ()))
-        err_exit ("error initializing parent window");
-    if (!(ostwin = newwin (ostcount + 1, 80, TOPWIN_LINES, 0)))
-        err_exit ("error initializing subwindow");
     raw ();
     noecho ();
     timeout (sample_period * 1000);
@@ -293,8 +459,8 @@ main (int argc, char *argv[])
     curs_set (0);
 
     /* Main processing loop:
-     * Update display, read kbd (or timeout), update ost_data & mdt_data,
-     *   create oss_data (summary of ost_data), [repeat]
+     * Update display, read kbd (or timeout), update ost/mdt_data,
+     *   create oss/mds_data (summary of ost/mdt_data), [repeat]
      */
     while (!isendwin ()) {
         if (showhelp) {
@@ -302,50 +468,74 @@ main (int argc, char *argv[])
         } else {
             _update_display_top (topwin, fs, ost_data, mdt_data, stale_secs,
                                  recf, playf, tcycle, pause);
-            _update_display_ost (ostwin, ostview ? ost_data : oss_data,
-                                 minost, selost, stale_secs, tcycle, ost_fp);
+            if (mdtwin) {
+                    _update_display_hdr (mdtwin,
+                                         sizeof(mdt_col)/sizeof(mdt_col[0]),
+                                         mdt_col, mdt_fp);
+                    _update_display_target (mdtwin,
+                                            mdtview ? mdt_data : mds_data,
+                                            minmdt, selmdt, stale_secs, tcycle,
+                                            _update_display_mdt);
+            }
+            if (ostwin) {
+                _update_display_hdr (ostwin, sizeof(ost_col)/sizeof(ost_col[0]),
+                                     ost_col, ost_fp);
+                _update_display_target (ostwin, ostview ? ost_data : oss_data,
+                                        minost, selost, stale_secs, tcycle,
+                                        _update_display_ost);
+            }
         }
         switch ((c = getch ())) {
+            case 'z':               /* z - toggle between OST and MDT window */
+            case 'Z':
+                if (mdtwin) {
+                    in_ostwin = !in_ostwin;
+                    recompute = 1;
+                }
+                break;
             case KEY_DC:            /* Delete - turn off highlighting */
-                selost = -1;
+                selost = selmdt = -1;
                 _clear_tags (ost_data);
                 _clear_tags (oss_data);
                 break;
             case 'q':               /* q|Ctrl-C - quit */
             case 0x03:
-                delwin (ostwin);
+                if (ostwin)
+                    delwin (ostwin);
+                if (mdtwin)
+                    delwin (mdtwin);
                 endwin ();
                 break;
             case KEY_UP:            /* UpArrow|k - move highlight up */
             case 'k':   /* vi */
-                if (selost > 0)
-                    selost--;
-                if (selost >= minost)
+                if (*seltgt > 0)
+                    (*seltgt)--;
+                if (*seltgt >= *mintgt)
                     break;
                 /* fall thru */
             case KEY_PPAGE:         /* PageUp|Ctrl-U - previous page */
             case 0x15:
-                minost -= (LINES - HDRLINES);
-                if (minost < 0)
-                    minost = 0;
+                *mintgt -= (*tgtlines-1);
+                if (*mintgt < 0)
+                    *mintgt = 0;
                 break;
             case KEY_DOWN:          /* DnArrow|j - move highlight down */
             case 'j':   /* vi */
-                if (selost < ostcount - 1)
-                    selost++;
-                if (selost - minost < LINES - HDRLINES)
+                if (*seltgt < *tgtcount - 1)
+                    (*seltgt)++;
+                if (*seltgt - *mintgt < (*tgtlines-1))
                     break;
                  /* fall thru */
             case KEY_NPAGE:         /* PageDn|Ctrl-D - next page */
             case 0x04:
-                if (minost + LINES - HDRLINES <= ostcount)
-                    minost += (LINES - HDRLINES);
+                if (*mintgt + *tgtlines <= *tgtcount)
+                    *mintgt += (*tgtlines-1);
                 break;
-            case 'c':               /* c - toggle compressed oss view */
-                ostview = !ostview;
+            case 'c':               /* c - toggle compressed server view */
+                *target_view = !(*target_view);
                 recompute = 1;
-                minost = 0;
-                selost = -1;
+                *mintgt = 0;
+                *seltgt = -1;
                 break;
             case ' ':               /* SPACE - tag selected OST */
                 if (ostview)
@@ -360,11 +550,14 @@ main (int argc, char *argv[])
                         free (fs);
                         fs = xstrdup (newfs);
                         repoll = 1;
+                        selost = selmdt = -1;
+                        minost = minmdt = 0;
+                        in_ostwin = 1;
                     }
                     free (newfs);
                 }
                 break;
-            case '>':               /* change sorting column (ost/oss) */
+            case '>':               /* change sorting column */
             case '<': 
             case 't': 
             case 's': 
@@ -379,8 +572,17 @@ main (int argc, char *argv[])
             case 'u': 
             case 'm': 
             case 'S': 
-                _sort_ostlist (ost_data, tcycle, c, &ost_fp); 
-                _sort_ostlist (oss_data, tcycle, 0, &ost_fp); 
+                if (in_ostwin) {
+                    ost_fp = _get_sort_index (c, ost_fp, ost_col,
+                                              sizeof(ost_col)/sizeof(ost_col[0]));
+                    _sort_tgtlist (ost_data, tcycle, ost_col[ost_fp].fun);
+                    _sort_tgtlist (oss_data, tcycle, ost_col[ost_fp].fun);
+                } else {
+                    mdt_fp = _get_sort_index (c, mdt_fp, mdt_col,
+                                              sizeof(mdt_col)/sizeof(mdt_col[0]));
+                    _sort_tgtlist (mdt_data, tcycle, mdt_col[mdt_fp].fun);
+                    _sort_tgtlist (mds_data, tcycle, mdt_col[mdt_fp].fun);
+                }
                 break;
             case 'R':               /* R - toggle record mode */
                 if (!playf) {
@@ -392,7 +594,8 @@ main (int argc, char *argv[])
                 }
                 break;
             case 'p':               /* p - pause playback */
-                pause = !pause;
+                if (playf)
+                    pause = !pause;
                 break;
             case KEY_LEFT:          /* LeftArrow - rewind 1 sample_period */
                 if (playf) {
@@ -453,12 +656,28 @@ main (int argc, char *argv[])
         }
         if (c != ERR && c != '?')
             showhelp = 0;
+
+        if (in_ostwin) {
+            mintgt = &minost;
+            seltgt = &selost;
+            tgtlines = &ostlines;
+            tgtcount = &ostcount;
+            target_view = &ostview;
+        } else {
+            mintgt = &minmdt;
+            seltgt = &selmdt;
+            tgtlines = &mdtlines;
+            tgtcount = &mdtcount;
+            target_view = &mdtview;
+        }
+
         if (repoll) {
             _list_empty_out (mdt_data);
             _list_empty_out (ost_data);
             repoll = 0;
             last_sample = 0; /* force resample */
         }
+
         if (time (NULL) - last_sample >= sample_period) {
             if (!pause) {
                 if (playf)
@@ -475,18 +694,34 @@ main (int argc, char *argv[])
             timeout ((sample_period - (time (NULL) - last_sample)) * 1000);
 
         if (recompute) {
+            mdtcount = list_count (mdtview ? mdt_data : mds_data);
             ostcount = list_count (ostview ? ost_data : oss_data);
-            delwin (ostwin);
-            if (!(ostwin = newwin (ostcount + 1, 80, TOPWIN_LINES, 0)))
-                err_exit ("error initializing subwindow");
+        }
+
+        size_windows(LINES, mdtcount, ostcount, &mdtlines, &ostlines);
+
+        if (recompute) {
+            if (mdtwin)
+                delwin (mdtwin);
+            if (ostwin)
+                delwin (ostwin);
+
+            create_target_window(&mdtwin, mdtlines, TOPWIN_LINES);
+
+            create_target_window(&ostwin, ostlines, TOPWIN_LINES + mdtlines);
+
             if (!ostview)
                 _summarize_ost (ost_data, oss_data, tcycle, stale_secs);
+            if (!mdtview)
+                _summarize_mdt (mdt_data, mds_data, tcycle, stale_secs);
             resort = 1;
             recompute = 0;
         }
         if (resort) {
-            _sort_ostlist (ost_data, tcycle, 0, &ost_fp); 
-            _sort_ostlist (oss_data, tcycle, 0, &ost_fp); 
+            _sort_tgtlist (ost_data, tcycle, ost_col[ost_fp].fun); 
+            _sort_tgtlist (oss_data, tcycle, ost_col[ost_fp].fun); 
+            _sort_tgtlist (mdt_data, tcycle, mdt_col[mdt_fp].fun);
+            _sort_tgtlist (mds_data, tcycle, mdt_col[mdt_fp].fun);
             resort = 0;
         }
     }
@@ -494,9 +729,10 @@ main (int argc, char *argv[])
     list_destroy (ost_data);
     list_destroy (mdt_data);
     list_destroy (oss_data);
+    list_destroy (mds_data);
     list_destroy (time_series);
     free (fs);
-    
+
     if (recf) {
         if (fclose (recf) == EOF)
             err ("Error closing %s", recpath);
@@ -508,6 +744,10 @@ main (int argc, char *argv[])
 }
 
 /* Show help window.
+ * Uppercase keys are used where lowercase is already taken.
+ * For some keys, meaning depends on whether OST or MDT is the
+ * currently selected window.
+ * Keep in sync wiht mdt_col[] and ost_col[].
  */
 static void _update_display_help (WINDOW *win)
 {
@@ -519,8 +759,9 @@ static void _update_display_help (WINDOW *win)
                META_VERSION, META_RELEASE);
     wattroff (win, A_REVERSE);
     y++;
-    mvwprintw (win, y++, 2, "PageUp     Page up through OST information");
-    mvwprintw (win, y++, 2, "PageDown   Page down through OST information");
+    mvwprintw (win, y++, 2, "z/Z        switch between OST/MDT window");
+    mvwprintw (win, y++, 2, "PageUp     Page up through targets");
+    mvwprintw (win, y++, 2, "PageDown   Page down through targets");
     mvwprintw (win, y++, 2, "UpArrow    Move cursor up");
     mvwprintw (win, y++, 2, "DownArrow  Move cursor down");
     mvwprintw (win, y++, 2, "Space      Tag/untag OST under cursor");
@@ -531,24 +772,36 @@ static void _update_display_help (WINDOW *win)
     mvwprintw (win, y++, 2, "LeftArrow  Rewind playback one sample period");
     mvwprintw (win, y++, 2, "Tab        Fast-fwd playback one minute");
     mvwprintw (win, y++, 2, "Backspace  Rewind playback one minute");
-    mvwprintw (win, y++, 2, "c          Toggle OST/OSS view");
+    mvwprintw (win, y++, 2, "c          Toggle target/server view");
     mvwprintw (win, y++, 2, "f          Select filesystem to monitor");
     mvwprintw (win, y++, 2, ">          Sort on next right column");
     mvwprintw (win, y++, 2, "<          Sort on next left column");
-    mvwprintw (win, y++, 2, "s          Sort on OSS name (ascending)");
-    mvwprintw (win, y++, 2, "x          Sort on export count (ascending)");
-    mvwprintw (win, y++, 2, "C          Sort on connect rate (descending)");
-    mvwprintw (win, y++, 2, "r          Sort on read b/w (descending)");
-    mvwprintw (win, y++, 2, "w          Sort on write b/w (descending)");
-    mvwprintw (win, y++, 2, "i          Sort on IOPS (descending)");
-    mvwprintw (win, y++, 2, "l          Sort on lock count (descending)");
-    mvwprintw (win, y++, 2, "g          Sort on lock grant rate (descending)");
-    mvwprintw (win, y++, 2, "L          Sort on lock cancellation rate (descending)");
+    mvwprintw (win, y++, 2, "t          Sort on target name (ascending)");
+    mvwprintw (win, y++, 2, "s          Sort on server name (ascending)");
+
+    mvwprintw (win, y++, 2, "x          Sort on export count (ascending/OST)");
+    mvwprintw (win, y++, 2, "C          Sort on connect rate (descending/OST)");
+    mvwprintw (win, y++, 2, "r          Sort on read b/w (descending/OST)");
+    mvwprintw (win, y++, 2, "w          Sort on write b/w (descending/OST)");
+    mvwprintw (win, y++, 2, "i          Sort on IOPS (descending/OST)");
+    mvwprintw (win, y++, 2, "l          Sort on lock count (descending/OST)");
+    mvwprintw (win, y++, 2, "g          Sort on lock grant rate (descending/OST)");
+    mvwprintw (win, y++, 2, "L          Sort on lock cancel  rate (descending/OST)");
+
+    mvwprintw (win, y++, 2, "o          Sort on open rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "C          Sort on close rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "g          Sort on getattr rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "S          Sort on setattr rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "U          Sort on unlink rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "M          Sort on mkdir rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "r          Sort on rmdir rate (descending/MDT)");
+    mvwprintw (win, y++, 2, "R          Sort on rename rate (descending/MDT)");
+
     mvwprintw (win, y++, 2, "u          Sort on %%cpu utilization (descending)");
     mvwprintw (win, y++, 2, "m          Sort on %%memory utilization (descending)");
     mvwprintw (win, y++, 2, "S          Sort on %%disk space utilization (descending)");
     mvwprintw (win, y++, 2, "q          Quit");
-              
+
     wrefresh (win);
 }
 
@@ -590,7 +843,7 @@ _update_display_top (WINDOW *win, char *fs, List ost_data, List mdt_data,
     itr = list_iterator_create (ost_data);
     while ((o = list_next (itr))) {
         rmbps         += sample_rate (o->rbytes, tnow) / (1024*1024);
-        wmbps         += sample_rate (o->wbytes, tnow) / (1024*1024);    
+        wmbps         += sample_rate (o->wbytes, tnow) / (1024*1024);
         iops          += sample_rate (o->iops, tnow);
         tbytes_free   += sample_val (o->kbytes_free, tnow) / (1024*1024*1024);
         tbytes_total  += sample_val (o->kbytes_total, tnow) / (1024*1024*1024);
@@ -786,14 +1039,16 @@ _find_all_fs (FILE *playf, int stale_secs)
 
     itr = list_iterator_create (mdt_data);
     while ((m = list_next (itr))) {
-        if (!(f = list_find_first (fsl, (ListFindF)_match_fsstat, m->fsname)))
-            list_append (fsl, _create_fsstat (m->fsname, 0));
+        if (!(f = list_find_first (fsl, (ListFindF)_match_fsstat,
+                                   m->common.fsname)))
+            list_append (fsl, _create_fsstat (m->common.fsname, 0));
     }
     list_iterator_destroy (itr);
     itr = list_iterator_create (ost_data);
     while ((o = list_next (itr))) {
-        if (!(f = list_find_first (fsl, (ListFindF)_match_fsstat, o->fsname)))
-            list_append (fsl, _create_fsstat (o->fsname, 1));
+        if (!(f = list_find_first (fsl, (ListFindF)_match_fsstat,
+                                   o->common.fsname)))
+            list_append (fsl, _create_fsstat (o->common.fsname, 1));
         else
             f->num_ost++;
     }
@@ -862,81 +1117,139 @@ _ltrunc (char *s, int max)
     return s + (len > max ? len - max : 0);
 }
 
-/* Update the ost window of the display.
- * Minost is the first ost to display (zero origin).
- * Selost is the selected ost, or -1 if none are selected (zero origin).
- * Stale_secs is the number of seconds after which data is expried.
- * i is the column currently used for sorting (zero origin).
- */
 static void
-_update_display_ost (WINDOW *win, List ost_data, int minost, int selost,
-                     int stale_secs, time_t tnow, int i)
+_update_display_hdr (WINDOW *win, int cols, sort_t colhdr[], int sel)
 {
-    ListIterator itr;
-    oststat_t *o;
-    int y = 0;
-    int skipost = minost;
+    int i;
 
     wclear (win);
-    wmove (win, y++, 0);
-
+    wmove (win, 0, 0);
     wattron (win, A_REVERSE);
-    wprintw (win, "%sOST",        i == 0  ? ">" : " ");
-    wprintw (win, "%sS",          i == 1  ? ">" : " ");
-    wprintw (win, "       %sOSS", i == 2  ? ">" : " ");
-    wprintw (win, "  %sExp",      i == 3  ? ">" : " ");
-    wprintw (win, "  %sCR",       i == 4  ? ">" : " ");
-    wprintw (win, "%srMB/s",      i == 5  ? ">" : " ");
-    wprintw (win, "%swMB/s",      i == 6  ? ">" : " ");
-    wprintw (win, " %sIOPS",      i == 7  ? ">" : " ");
-    wprintw (win, "  %sLOCKS",    i == 8  ? ">" : " ");
-    wprintw (win, " %sLGR",       i == 9  ? ">" : " ");
-    wprintw (win, " %sLCR",       i == 10 ? ">" : " ");
-    wprintw (win, "%s%%cpu",      i == 11 ? ">" : " ");
-    wprintw (win, "%s%%mem",      i == 12 ? ">" : " ");
-    wprintw (win, "%s%%spc",      i == 13 ? ">" : " ");
+    for(i=0;i<cols;i++) {
+        wprintw (win, colhdr[i].h,  sel == i  ? ">" : " ");
+    }
     wattroff(win, A_REVERSE);
+    wrefresh (win);
+}
 
-    itr = list_iterator_create (ost_data);
-    while ((o = list_next (itr))) {
-        if (skipost-- > 0)
+static void
+_update_display_mdt (WINDOW *win, int line, void *target, int stale_secs,
+                     time_t tnow)
+{
+    mdtstat_t *m = (mdtstat_t *) target;
+
+    /* Future enhancement: if all "osc status" reported by an
+     * MDT are the same, print the corresponding single
+     * character.  If not, print a character indicating
+     * "mixed" (update man page).
+     * Same for OST.  Then you get clear indicators for
+     * common issues (e.g. OSS died).
+     * For now, omit that field for the MDTs.
+     * See: osc.c:_get_oscstring()
+     *      proc_lustre_oscinfo()
+     *      fs/lustre/osc/%s/ost_server_uuid
+     *      fs/lustre/osc/%s/state
+     *      man ltop "OSC status"
+     *      comment at _update_osc()
+     */
+
+    if ((tnow - m->common.tgt_metric_timestamp) > stale_secs) {
+        // available info is expired 
+        mvwprintw (win, line, 0, "%4.4s data is stale", m->common.name);
+    } else if (m->common.recov_status &&
+               strstr(m->common.recov_status,"RECOV")) {
+        /* mdt is in recovery - display recovery stats */
+        mvwprintw (win, line, 0, "%4.4s   %10.10s %s",
+                   m->common.name, _ltrunc (m->common.servername, 10),
+                   m->common.recov_status);
+    } else {
+        /* mdt is not in recovery */
+        mvwprintw (win, line, 0, "%4.4s %12.12s"
+                   " %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f %5.0f"
+                   " %5.0f %5.0f",
+                   m->common.name, _ltrunc (m->common.servername, 10),
+                   sample_rate (m->open, tnow),
+                   sample_rate (m->close, tnow),
+                   sample_rate (m->getattr, tnow),
+                   sample_rate (m->setattr, tnow),
+                   sample_rate (m->unlink, tnow),
+                   sample_rate (m->mkdir, tnow),
+                   sample_rate (m->rmdir, tnow),
+                   sample_rate (m->rename, tnow),
+                   sample_val (m->common.pct_cpu, tnow),
+                   sample_val (m->common.pct_mem, tnow)
+                   );
+    }
+}
+
+static void
+_update_display_ost (WINDOW *win, int line, void *target, int stale_secs,
+                     time_t tnow)
+{
+    oststat_t *o = (oststat_t *) target;
+
+    double ktot = sample_val (o->kbytes_total, tnow);
+    double kfree = sample_val (o->kbytes_free, tnow);
+    double pct_used = ktot > 0 ? ((ktot - kfree) / ktot)*100.0 : 0;
+
+    /* available info is expired */
+    if ((tnow - o->common.tgt_metric_timestamp) > stale_secs) {
+        mvwprintw (win, line, 0, "%4.4s %1.1s data is stale",
+                   o->common.name, o->common.tgtstate);
+    /* ost is in recovery - display recovery stats */
+    } else if (strncmp (o->common.recov_status, "COMPLETE", 8) != 0
+            && strncmp (o->common.recov_status, "INACTIVE", 8) != 0) {
+        mvwprintw (win, line, 0, "%4.4s %1.1s %10.10s   %s",
+                   o->common.name, o->common.tgtstate,
+                   _ltrunc (o->common.servername, 10),
+                   o->common.recov_status);
+    /* ost is not in recover (state == INACTIVE|COMPLETE) */
+    } else {
+        mvwprintw (win, line, 0, "%4.4s %1.1s %10.10s"
+                   " %5.0f %4.0f %5.0f %5.0f %5.0f %7.0f %4.0f %4.0f"
+                   " %4.0f %4.0f %4.0f",
+                   o->common.name, o->common.tgtstate,
+                   _ltrunc (o->common.servername, 10),
+                   sample_val (o->num_exports, tnow),
+                   sample_rate (o->connect, tnow),
+                   sample_rate (o->rbytes, tnow) / (1024*1024),
+                   sample_rate (o->wbytes, tnow) / (1024*1024),
+                   sample_rate (o->iops, tnow),
+                   sample_val (o->lock_count, tnow),
+                   sample_val (o->grant_rate, tnow),
+                   sample_val (o->cancel_rate, tnow),
+                   sample_val (o->common.pct_cpu, tnow),
+                   sample_val (o->common.pct_mem, tnow),
+                   pct_used);
+    }
+}
+
+/* Update the ost/oss or mdt/mds window of the display.
+ * tgt is either an mdt, mds, ost, or oss
+ * Mintgt is the first tgt to display (zero origin).
+ * Seltgt is the selected tgt, or -1 if none are selected (zero origin).
+ * Stale_secs is the number of seconds after which data is expried.
+ * _display_line_fn is the function to call to display one target.
+ */
+static void
+_update_display_target (WINDOW *win, List tgt_data, int mintgt, int seltgt,
+                     int stale_secs, time_t tnow, _display_line_fn fn)
+{
+    ListIterator        itr;
+    generic_target_t    *o;
+    int                 y = 1;
+    int                 skiptgt = mintgt;
+
+    itr = list_iterator_create (tgt_data);
+    while ((o = (generic_target_t *) list_next (itr))) {
+        if (skiptgt-- > 0)
             continue;
-        if (y - 1 + minost == selost)
+        if (y - 1 + mintgt == seltgt)
             wattron (win, A_REVERSE);
         if (o->tag)
             wattron (win, A_UNDERLINE);
-        /* available info is expired */
-        if ((tnow - o->ost_metric_timestamp) > stale_secs) {
-            mvwprintw (win, y, 0, "%4.4s %1.1s", o->name, o->oscstate);
-        /* ost is in recovery - display recovery stats */
-        } else if (strncmp (o->recov_status, "COMPLETE", 8) != 0
-                && strncmp (o->recov_status, "INACTIVE", 8) != 0) {
-            mvwprintw (win, y, 0, "%4.4s %1.1s %10.10s   %s",
-                       o->name, o->oscstate, _ltrunc (o->ossname, 10),
-                       o->recov_status);
-        /* ost is not in recover (state == INACTIVE|COMPLETE) */
-        } else {
-            double ktot = sample_val (o->kbytes_total, tnow);
-            double kfree = sample_val (o->kbytes_free, tnow);
-            double pct_used = ktot > 0 ? ((ktot - kfree) / ktot)*100.0 : 0;
-
-            mvwprintw (win, y, 0, "%4.4s %1.1s %10.10s"
-                       " %5.0f %4.0f %5.0f %5.0f %5.0f %7.0f %4.0f %4.0f"
-                       " %4.0f %4.0f %4.0f",
-                       o->name, o->oscstate, _ltrunc (o->ossname, 10),
-                       sample_val (o->num_exports, tnow),
-                       sample_rate (o->connect, tnow),
-                       sample_rate (o->rbytes, tnow) / (1024*1024),
-                       sample_rate (o->wbytes, tnow) / (1024*1024),
-                       sample_rate (o->iops, tnow),
-                       sample_val (o->lock_count, tnow),
-                       sample_val (o->grant_rate, tnow),
-                       sample_val (o->cancel_rate, tnow),
-                       sample_val (o->pct_cpu, tnow),
-                       sample_val (o->pct_mem, tnow),
-                       pct_used);
-        }
-        if (y - 1 + minost == selost)
+        fn (win, y, o, stale_secs, tnow);
+        if (y - 1 + mintgt == seltgt)
             wattroff(win, A_REVERSE);
         if (o->tag)
             wattroff(win, A_UNDERLINE);
@@ -947,7 +1260,16 @@ _update_display_ost (WINDOW *win, List ost_data, int minost, int selost,
     wrefresh (win);
 }
 
-/*  Used for list_find_first () of MDT by filesystem and target name, e.g. fs-MDTxxxx.
+/*  Used for list_find_first () of MDT by mds name.
+ */
+static int
+_match_mdtstat2 (mdtstat_t *m, char *name)
+{
+    return (strcmp (m->common.servername, name) == 0);
+}
+
+/*  Used for list_find_first () of MDT by filesystem and target name,
+ *  e.g. fs-MDTxxxx.
  */
 static int
 _match_mdtstat (mdtstat_t *m, char *name)
@@ -956,10 +1278,37 @@ _match_mdtstat (mdtstat_t *m, char *name)
     int fsmatch;
     char *p = strstr (name, "-MDT");
 
-    fsmatch = _fsmatch(name, m->fsname);
-    targetmatch = (strcmp (m->name, p ? p + 4 : name) == 0);
+    fsmatch = _fsmatch(name, m->common.fsname);
+    targetmatch = (strcmp (m->common.name, p ? p + 4 : name) == 0);
 
     return (targetmatch && fsmatch);
+}
+
+/* Copy an mdtstat record.
+ */
+static void *
+_copy_mdtstat (void *src_v)
+{
+    mdtstat_t *src = (mdtstat_t *) src_v;
+    mdtstat_t *m = xmalloc (sizeof (*m));
+
+    memcpy (m, src, sizeof (*m));
+    m->inodes_free =  sample_copy (src->inodes_free);
+    m->inodes_total = sample_copy (src->inodes_total);
+    m->open =         sample_copy (src->open);
+    m->close =        sample_copy (src->close);
+    m->getattr =      sample_copy (src->getattr);
+    m->setattr =      sample_copy (src->setattr);
+    m->link =         sample_copy (src->link);
+    m->unlink =       sample_copy (src->unlink);
+    m->mkdir =        sample_copy (src->mkdir);
+    m->rmdir =        sample_copy (src->rmdir);
+    m->statfs =       sample_copy (src->statfs);
+    m->rename =       sample_copy (src->rename);
+    m->common.pct_cpu =      sample_copy (src->common.pct_cpu);
+    m->common.pct_mem =      sample_copy (src->common.pct_mem);
+    m->getxattr =     sample_copy (src->getxattr);
+    return (void *) m;
 }
 
 /* Create an mdtstat record.
@@ -971,10 +1320,11 @@ _create_mdtstat (char *name, int stale_secs)
     char *mdtx = strstr (name, "-MDT");
 
     memset (m, 0, sizeof (*m));
-    strncpy (m->name, mdtx ? mdtx + 4 : name, sizeof(m->name) - 1);
-    strncpy (m->fsname, name, mdtx ? mdtx - name : sizeof (m->fsname) - 1);
-    *m->tgtstate = '\0';
-    *m->recov_status='\0';
+    strncpy (m->common.name, mdtx ? mdtx + 4 : name, sizeof(m->common.name)-1);
+    strncpy (m->common.fsname, name,
+             mdtx ? mdtx - name : sizeof (m->common.fsname)-1);
+    *m->common.tgtstate = '\0';
+    *m->common.recov_status='\0';
     m->inodes_free =  sample_create (stale_secs);
     m->inodes_total = sample_create (stale_secs);
     m->open =         sample_create (stale_secs);
@@ -987,6 +1337,8 @@ _create_mdtstat (char *name, int stale_secs)
     m->rmdir =        sample_create (stale_secs);
     m->statfs =       sample_create (stale_secs);
     m->rename =       sample_create (stale_secs);
+    m->common.pct_cpu =      sample_create (stale_secs);
+    m->common.pct_mem =      sample_create (stale_secs);
     m->getxattr =     sample_create (stale_secs);
     return m;
 }
@@ -1008,6 +1360,8 @@ _destroy_mdtstat (mdtstat_t *m)
     sample_destroy (m->rmdir);
     sample_destroy (m->statfs);
     sample_destroy (m->rename);
+    sample_destroy (m->common.pct_cpu);
+    sample_destroy (m->common.pct_mem);
     sample_destroy (m->getxattr);
     free (m);
 }
@@ -1021,8 +1375,8 @@ _match_oststat (oststat_t *o, char *name)
     int fsmatch;
     char *p = strstr (name, "-OST");
 
-    fsmatch = _fsmatch(name, o->fsname);
-    targetmatch = (strcmp (o->name, p ? p + 4 : name) == 0);
+    fsmatch = _fsmatch(name, o->common.fsname);
+    targetmatch = (strcmp (o->common.name, p ? p + 4 : name) == 0);
 
     return (targetmatch && fsmatch);
 }
@@ -1032,10 +1386,10 @@ _match_oststat (oststat_t *o, char *name)
 static int
 _match_oststat2 (oststat_t *o, char *name)
 {
-    return (strcmp (o->ossname, name) == 0);
+    return (strcmp (o->common.servername, name) == 0);
 }
 
-/* Helper for _cmp_ostatst2 ()
+/* Helper for _cmp_server_names ()
  */
 static char *
 _numerical_suffix (char *s, unsigned long *np)
@@ -1049,32 +1403,70 @@ _numerical_suffix (char *s, unsigned long *np)
     return p;
 }
 
-/* Used for list_sort () of OST list by ossname.
- * Like strcmp, but handle variable-width (unpadded) numerical suffixes, if any.
+/* Helper for _cmp_oststat_byoss () and _cmp_mdtstat_bymds () Like
+ * strcmp, but handle variable-width (unpadded) numerical suffixes, if
+ * any.
  */
 static int
-_cmp_oststat_byoss (oststat_t *o1, oststat_t *o2)
+_cmp_server_names (char *servername1, char *servername2)
 {
     unsigned long n1, n2;
-    char *p1 = _numerical_suffix (o1->ossname, &n1);
-    char *p2 = _numerical_suffix (o2->ossname, &n2);
+    char *p1 = _numerical_suffix (servername1, &n1);
+    char *p2 = _numerical_suffix (servername2, &n2);
 
     if (*p1 && *p2
-            && (p1 - o1->ossname) == (p2 - o2->ossname)
-            && !strncmp (o1->ossname, o2->ossname, p1 - o1->ossname)) {
+            && (p1 - servername1) == (p2 - servername2)
+            && !strncmp (servername1, servername2, p1 - servername1)) {
         return (n1 < n2 ? -1 
               : n1 > n2 ? 1 : 0);
     }
-    return strcmp (o1->ossname, o2->ossname);
+    return strcmp (servername1, servername2);
 }
 
-/* Used for list_sort () of OST list by ostname.
+/* Used for list_sort () of OST or MDT list by servername.
+ * See _cmp_server_names for details.
+ */
+static int
+_cmp_tgtstat_byserver (void *p1, void *p2)
+{
+    return _cmp_server_names (((generic_target_t *) p1)->servername,
+                              ((generic_target_t *) p2)->servername);
+}
+
+/* Used for list_sort () of OST/MDT list by target name.
  * Fixed width hex sorts alphanumerically.
  */
 static int
-_cmp_oststat_byost (oststat_t *o1, oststat_t *o2)
+_cmp_tgtstat_bytarget (void *p1, void *p2)
 {
-    return strcmp (o1->name, o2->name);
+    return strcmp (((generic_target_t *) p1)->name,
+                   ((generic_target_t *) p2)->name);
+}
+
+/* Used for list_sort () of OST/MDT list by pct_mem (descending order).
+ */
+static int
+_cmp_tgtstat_bymem (void *p1, void *p2)
+{
+    return -1 * sample_val_cmp (((generic_target_t *) p1)->pct_mem,
+                                ((generic_target_t *) p2)->pct_mem, sort_tnow);
+}
+
+/* Used for list_sort () of OST/MDT list by pct_cpu (descending order).
+ */
+static int
+_cmp_tgtstat_bycpu (void *p1, void *p2)
+{
+    return -1 * sample_val_cmp (((generic_target_t *) p1)->pct_cpu,
+                                ((generic_target_t *) p2)->pct_cpu, sort_tnow);
+}
+
+/* Used for no-op list_sort () of OST/MDT list.
+ */
+static int
+_cmp_tgtstat_noop (void *p1, void *p2)
+{
+    return 0;
 }
 
 /* Used for list_sort () of OST list by export count (ascending order).
@@ -1141,29 +1533,6 @@ _cmp_oststat_bywbw (oststat_t *o1, oststat_t *o2)
     return -1 * sample_rate_cmp (o1->wbytes, o2->wbytes, sort_tnow);
 }
 
-/* Used for list_sort () of OST list by pct_mem (descending order).
- */
-static int
-_cmp_oststat_bymem (oststat_t *o1, oststat_t *o2)
-{
-    return -1 * sample_val_cmp (o1->pct_mem, o2->pct_mem, sort_tnow);
-}
-
-/* Used for list_sort () of OST list by pct_cpu (descending order).
- */
-static int
-_cmp_oststat_bycpu (oststat_t *o1, oststat_t *o2)
-{
-    return -1 * sample_val_cmp (o1->pct_cpu, o2->pct_cpu, sort_tnow);
-}
-
-/* Used for no-op list_sort () of OST list.
- */
-static int
-_cmp_oststat_noop (oststat_t *o1, oststat_t *o2)
-{
-    return 0;
-}
 
 /* Used for list_sort () of OST list by pct space used (descending order).
  */
@@ -1181,6 +1550,70 @@ _cmp_oststat_byspc (oststat_t *o1, oststat_t *o2)
     return -1 * ret;
 }
 
+/* Used for list_sort () of MDT list by opens (descending order).
+ */
+static int
+_cmp_mdtstat_byopen (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->open, m2->open, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by closes (descending order).
+ */
+static int
+_cmp_mdtstat_byclose (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->close, m2->close, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by getattrs (descending order).
+ */
+static int
+_cmp_mdtstat_bygetattr (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->getattr, m2->getattr, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by setattrs (descending order).
+ */
+static int
+_cmp_mdtstat_bysetattr (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->setattr, m2->setattr, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by unlinks (descending order).
+ */
+static int
+_cmp_mdtstat_byunlink (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->unlink, m2->unlink, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by rmdirs (descending order).
+ */
+static int
+_cmp_mdtstat_byrmdir (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->rmdir, m2->rmdir, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by mkdirs (descending order).
+ */
+static int
+_cmp_mdtstat_bymkdir (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->mkdir, m2->mkdir, sort_tnow);
+}
+
+/* Used for list_sort () of MDT list by renames (descending order).
+ */
+static int
+_cmp_mdtstat_byrename (mdtstat_t *m1, mdtstat_t *m2)
+{
+    return -1 * sample_rate_cmp (m1->rename, m2->rename, sort_tnow);
+}
+
 /* Create an oststat record.
  */
 static oststat_t *
@@ -1190,9 +1623,11 @@ _create_oststat (char *name, int stale_secs)
     char *ostx = strstr (name, "-OST");
 
     memset (o, 0, sizeof (*o));
-    strncpy (o->name, ostx ? ostx + 4 : name, sizeof(o->name) - 1);
-    strncpy (o->fsname, name, ostx ? ostx - name : sizeof (o->fsname) - 1);
-    *o->oscstate = '\0';
+    strncpy (o->common.name, ostx ? ostx + 4 : name, sizeof(o->common.name) - 1);
+    strncpy (o->common.fsname, name,
+             ostx ? ostx - name : sizeof (o->common.fsname) - 1);
+    *o->common.tgtstate = '\0';
+    *o->common.recov_status='\0';
     o->rbytes =       sample_create (stale_secs);
     o->wbytes =       sample_create (stale_secs);
     o->iops =         sample_create (stale_secs);
@@ -1203,8 +1638,8 @@ _create_oststat (char *name, int stale_secs)
     o->connect =      sample_create (stale_secs);
     o->kbytes_free =  sample_create (stale_secs);
     o->kbytes_total = sample_create (stale_secs);
-    o->pct_cpu      = sample_create (stale_secs);
-    o->pct_mem      = sample_create (stale_secs);
+    o->common.pct_cpu      = sample_create (stale_secs);
+    o->common.pct_mem      = sample_create (stale_secs);
     return o;
 }
 
@@ -1223,16 +1658,17 @@ _destroy_oststat (oststat_t *o)
     sample_destroy (o->connect);
     sample_destroy (o->kbytes_free);
     sample_destroy (o->kbytes_total);
-    sample_destroy (o->pct_cpu);
-    sample_destroy (o->pct_mem);
+    sample_destroy (o->common.pct_cpu);
+    sample_destroy (o->common.pct_mem);
     free (o);
 }
 
 /* Copy an oststat record.
  */
-static oststat_t *
-_copy_oststat (oststat_t *o1)
+static void *
+_copy_oststat (void *src)
 {
+    oststat_t *o1 = (oststat_t *) src;
     oststat_t *o = xmalloc (sizeof (*o));
 
     memcpy (o, o1, sizeof (*o));
@@ -1246,9 +1682,9 @@ _copy_oststat (oststat_t *o1)
     o->connect =      sample_copy (o1->connect);
     o->kbytes_free =  sample_copy (o1->kbytes_free);
     o->kbytes_total = sample_copy (o1->kbytes_total);
-    o->pct_cpu      = sample_copy (o1->pct_cpu);
-    o->pct_mem      = sample_copy (o1->pct_mem);
-    return o;
+    o->common.pct_cpu      = sample_copy (o1->common.pct_cpu);
+    o->common.pct_mem      = sample_copy (o1->common.pct_mem);
+    return (void *) o;
 }
 
 /* Match an OST or MDT target against a file system name.
@@ -1266,7 +1702,7 @@ _fsmatch (char *name, char *fs)
     return 0;
 }
 
-/* Update oststat_t record (oscstate field) in ost_data list for
+/* Update oststat_t record (tgtstate field) in ost_data list for
  * specified ostname.  Create an entry if one doesn't exist.
  * FIXME(design): we only keep one OSC state per OST, but possibly multiple
  * MDT's are reporting it under CMD and last in wins.
@@ -1282,41 +1718,41 @@ _update_osc (char *name, char *state, List ost_data,
         list_append (ost_data, o);
     }
     if (tnow - trcv > stale_secs)
-        strncpy (o->oscstate, "", sizeof (o->oscstate) - 1);
-    else    
-        strncpy (o->oscstate, state, sizeof (o->oscstate) - 1);
+        strncpy (o->common.tgtstate, "", sizeof (o->common.tgtstate) - 1);
+    else
+        strncpy (o->common.tgtstate, state, sizeof (o->common.tgtstate) - 1);
 }
 
 static void
 _decode_osc_v1 (char *val, char *fs, List ost_data,
              time_t tnow, time_t trcv, int stale_secs)
 {
-    char *s, *mdsname, *oscname, *oscstate;
+    char *s, *servername, *oscname, *tgtstate;
     List oscinfo;
     ListIterator itr;
 
-    if (lmt_osc_decode_v1 (val, &mdsname, &oscinfo) < 0)
+    if (lmt_osc_decode_v1 (val, &servername, &oscinfo) < 0)
         return;
     itr = list_iterator_create (oscinfo);
     while ((s = list_next (itr))) {
-        if (lmt_osc_decode_v1_oscinfo (s, &oscname, &oscstate) >= 0) {
+        if (lmt_osc_decode_v1_oscinfo (s, &oscname, &tgtstate) >= 0) {
             if (!fs || _fsmatch (oscname, fs))
-                _update_osc (oscname, oscstate, ost_data,
+                _update_osc (oscname, tgtstate, ost_data,
                              tnow, trcv, stale_secs);
             free (oscname);
-            free (oscstate);
+            free (tgtstate);
         }
     }
     list_iterator_destroy (itr);
     list_destroy (oscinfo);
-    free (mdsname);
+    free (servername);
 }
 
 /* Update oststat_t record in ost_data list for specified ostname.
  * Create an entry if one doesn't exist.
  */
 static void
-_update_ost (char *ostname, char *ossname, uint64_t read_bytes,
+_update_ost (char *ostname, char *servername, uint64_t read_bytes,
              uint64_t write_bytes, uint64_t iops, uint64_t num_exports,
              uint64_t lock_count, uint64_t grant_rate, uint64_t cancel_rate,
              uint64_t connect, char *recov_status, uint64_t kbytes_free,
@@ -1329,8 +1765,8 @@ _update_ost (char *ostname, char *ossname, uint64_t read_bytes,
         o = _create_oststat (ostname, stale_secs);
         list_append (ost_data, o);
     }
-    if (o->ost_metric_timestamp < trcv) {
-        if (strcmp (ossname, o->ossname) != 0) { /* failover/failback */
+    if (o->common.tgt_metric_timestamp < trcv) {
+        if (strcmp (servername, o->common.servername) != 0) { /*failover/back*/
             sample_invalidate (o->rbytes);
             sample_invalidate (o->wbytes);
             sample_invalidate (o->iops);
@@ -1338,11 +1774,12 @@ _update_ost (char *ostname, char *ossname, uint64_t read_bytes,
             sample_invalidate (o->lock_count);
             sample_invalidate (o->kbytes_free);
             sample_invalidate (o->kbytes_total);
-            sample_invalidate (o->pct_cpu);
-            sample_invalidate (o->pct_mem);
-            snprintf (o->ossname, sizeof (o->ossname), "%s", ossname);
+            sample_invalidate (o->common.pct_cpu);
+            sample_invalidate (o->common.pct_mem);
+            snprintf (o->common.servername, sizeof (o->common.servername),
+                      "%s", servername);
         }
-        o->ost_metric_timestamp = trcv;
+        o->common.tgt_metric_timestamp = trcv;
         sample_update (o->rbytes, (double)read_bytes, trcv);
         sample_update (o->wbytes, (double)write_bytes, trcv);
         sample_update (o->iops, (double)iops, trcv);
@@ -1353,9 +1790,10 @@ _update_ost (char *ostname, char *ossname, uint64_t read_bytes,
         sample_update (o->connect, (double)connect, trcv);
         sample_update (o->kbytes_free, (double)kbytes_free, trcv);
         sample_update (o->kbytes_total, (double)kbytes_total, trcv);
-        sample_update (o->pct_cpu, (double)pct_cpu, trcv);
-        sample_update (o->pct_mem, (double)pct_mem, trcv);
-        snprintf (o->recov_status, sizeof(o->recov_status), "%s", recov_status);
+        sample_update (o->common.pct_cpu, (double)pct_cpu, trcv);
+        sample_update (o->common.pct_mem, (double)pct_mem, trcv);
+        snprintf (o->common.recov_status, sizeof(o->common.recov_status),
+                  "%s", recov_status);
     }
 }
 
@@ -1364,7 +1802,7 @@ _decode_ost_v2 (char *val, char *fs, List ost_data,
                 time_t tnow, time_t trcv, int stale_secs)
 {
     List ostinfo;
-    char *s, *p, *ossname, *ostname, *recov_status;
+    char *s, *p, *servername, *ostname, *recov_status;
     float pct_cpu, pct_mem;
     uint64_t read_bytes, write_bytes;
     uint64_t kbytes_free, kbytes_total;
@@ -1373,11 +1811,11 @@ _decode_ost_v2 (char *val, char *fs, List ost_data,
     uint64_t lock_count, grant_rate, cancel_rate;
     uint64_t connect, reconnect;
     ListIterator itr;
-    
-    if (lmt_ost_decode_v2 (val, &ossname, &pct_cpu, &pct_mem, &ostinfo) < 0)
+
+    if (lmt_ost_decode_v2 (val, &servername, &pct_cpu, &pct_mem, &ostinfo) < 0)
         return;
     /* Issue 53: drop domain name, if any */
-    if ((p = strchr (ossname, '.')))
+    if ((p = strchr (servername, '.')))
         *p = '\0';
     itr = list_iterator_create (ostinfo);
     while ((s = list_next (itr))) {
@@ -1390,7 +1828,7 @@ _decode_ost_v2 (char *val, char *fs, List ost_data,
                                        &connect, &reconnect,
                                        &recov_status) == 0) {
             if (!fs || _fsmatch (ostname, fs)) {
-                _update_ost (ostname, ossname, read_bytes, write_bytes,
+                _update_ost (ostname, servername, read_bytes, write_bytes,
                              iops, num_exports, lock_count, grant_rate,
                              cancel_rate, connect + reconnect, recov_status,
                              kbytes_free, kbytes_total, pct_cpu, pct_mem,
@@ -1402,14 +1840,14 @@ _decode_ost_v2 (char *val, char *fs, List ost_data,
     }
     list_iterator_destroy (itr);
     list_destroy (ostinfo);
-    free (ossname);
+    free (servername);
 }
 
 /* Update mdtstat_t record in mdt_data list for specified mdtname.
  * Create an entry if one doesn't exist.
  */
 static void
-_update_mdt (char *mdtname, char *mdsname, uint64_t inodes_free,
+_update_mdt (char *mdtname, char *servername, uint64_t inodes_free,
              uint64_t inodes_total, uint64_t kbytes_free,
              uint64_t kbytes_total, float pct_cpu, float pct_mem,
              char *recov_status, List mdops, List mdt_data, time_t tnow,
@@ -1427,8 +1865,8 @@ _update_mdt (char *mdtname, char *mdsname, uint64_t inodes_free,
         m = _create_mdtstat (mdtname, stale_secs);
         list_append (mdt_data, m);
     }
-    if (m->mdt_metric_timestamp < trcv) {
-        if (strcmp (mdsname, m->mdsname) != 0) { /* failover/failback */
+    if (m->common.tgt_metric_timestamp < trcv) {
+        if (strcmp (servername, m->common.servername) != 0) { /*failover/back*/
             sample_invalidate (m->inodes_free);
             sample_invalidate (m->inodes_total);
             sample_invalidate (m->open);
@@ -1442,14 +1880,20 @@ _update_mdt (char *mdtname, char *mdsname, uint64_t inodes_free,
             sample_invalidate (m->statfs);
             sample_invalidate (m->rename);
             sample_invalidate (m->getxattr);
-            snprintf (m->mdsname, sizeof (m->mdsname), "%s", mdsname);
-            m->recov_status[0]='\0';
+            sample_invalidate (m->common.pct_cpu);
+            sample_invalidate (m->common.pct_mem);
+            snprintf (m->common.servername, sizeof (m->common.servername),
+                      "%s", servername);
+            m->common.recov_status[0]='\0';
         }
-        m->mdt_metric_timestamp = trcv;
+        m->common.tgt_metric_timestamp = trcv;
         sample_update (m->inodes_free, (double)inodes_free, trcv);
         sample_update (m->inodes_total, (double)inodes_total, trcv);
+        sample_update (m->common.pct_cpu, (double)pct_cpu, trcv);
+        sample_update (m->common.pct_mem, (double)pct_mem, trcv);
         if (version==2)
-            snprintf (m->recov_status, sizeof (m->recov_status), "%s", recov_status);
+            snprintf (m->common.recov_status, sizeof (m->common.recov_status),
+                      "%s", recov_status);
         itr = list_iterator_create (mdops);
         while ((s = list_next (itr))) {
             if (lmt_mdt_decode_v1_mdops (s, &opname,
@@ -1488,13 +1932,13 @@ _decode_mdt_v1 (char *val, char *fs, List mdt_data,
                 time_t tnow, time_t trcv, int stale_secs)
 {
     List mdops, mdtinfo;
-    char *s, *mdsname, *mdtname;
+    char *s, *servername, *mdtname;
     float pct_cpu, pct_mem;
     uint64_t kbytes_free, kbytes_total;
     uint64_t inodes_free, inodes_total;
     ListIterator itr;
 
-    if (lmt_mdt_decode_v1_v2 (val, &mdsname, &pct_cpu, &pct_mem, &mdtinfo, 1) < 0)
+    if (lmt_mdt_decode_v1_v2 (val, &servername, &pct_cpu, &pct_mem, &mdtinfo, 1) < 0)
         return;
     itr = list_iterator_create (mdtinfo);
     while ((s = list_next (itr))) {
@@ -1502,7 +1946,7 @@ _decode_mdt_v1 (char *val, char *fs, List mdt_data,
                                        &inodes_total, &kbytes_free,
                                        &kbytes_total, &mdops) == 0) {
             if (!fs || _fsmatch (mdtname, fs)) {
-                _update_mdt (mdtname, mdsname, inodes_free, inodes_total,
+                _update_mdt (mdtname, servername, inodes_free, inodes_total,
                              kbytes_free, kbytes_total, pct_cpu, pct_mem,
                              NULL, mdops, mdt_data, tnow, trcv, stale_secs,
                              1);
@@ -1513,7 +1957,7 @@ _decode_mdt_v1 (char *val, char *fs, List mdt_data,
     }
     list_iterator_destroy (itr);
     list_destroy (mdtinfo);
-    free (mdsname);
+    free (servername);
 }
 
 static void
@@ -1540,8 +1984,8 @@ _decode_mdt_v2 (char *val, char *fs, List mdt_data,
             if (!fs || _fsmatch (mdtname, fs))
                 _update_mdt (mdtname, mdsname, inodes_free, inodes_total,
                              kbytes_free, kbytes_total, pct_cpu, pct_mem,
-                             recov_info, mdops, mdt_data, tnow, trcv, stale_secs,
-                             2);
+                             recov_info, mdops, mdt_data, tnow, trcv,
+                             stale_secs, 2);
             free (mdtname);
             list_destroy (mdops);
         }
@@ -1731,160 +2175,158 @@ _find_first_fs (FILE *playf, int stale_secs)
     return ret;
 }
 
+static void
+_single_ost_update_summary (void *ost_v, void *summary_v)
+{
+    oststat_t *ost        = (oststat_t *) ost_v;
+    oststat_t *summary    = (oststat_t *) summary_v;
+
+    sample_add (summary->rbytes, ost->rbytes);
+    sample_add (summary->wbytes, ost->wbytes);
+    sample_add (summary->iops, ost->iops);
+    sample_add (summary->kbytes_free, ost->kbytes_free);
+    sample_add (summary->kbytes_total, ost->kbytes_total);
+    sample_add (summary->lock_count, ost->lock_count);
+    sample_add (summary->grant_rate, ost->grant_rate);
+    sample_add (summary->cancel_rate, ost->cancel_rate);
+    sample_add (summary->connect, ost->connect);
+
+    /* Any "missing clients" on OST's should be reflected in OSS exp.
+     */
+    sample_min (summary->num_exports, ost->num_exports);
+    
+    if (ost->common.tag)
+        summary->common.tag = ost->common.tag;
+}
+
+static void
+_summarize_target (List target_data, List server_data, time_t tnow,
+                   int stale_secs, _tgt_update_summary update_fn,
+                   _copy_tgtstat copy_fn, ListFindF cmp_fn)
+{
+    generic_target_t *target, *server;
+    ListIterator itr;
+
+    _list_empty_out (server_data);
+    itr = list_iterator_create (target_data);
+    while ((target = list_next (itr))) {
+        if (tnow - target->tgt_metric_timestamp > stale_secs)
+            continue;
+        server = list_find_first (server_data, (ListFindF) cmp_fn,
+                                  target->servername);
+        if (server) {
+            update_fn( (void *) target, (void *) server );
+            if (target->tgt_metric_timestamp < server->tgt_metric_timestamp)
+                server->tgt_metric_timestamp = target->tgt_metric_timestamp;
+            /* Ensure recov_status and tgtstate reflect any unrecovered or
+             * non-full state of individual targets.  Last in wins.
+             */
+            if (strcmp (target->tgtstate, "F") != 0)
+                memcpy (server->tgtstate, target->tgtstate,
+                        sizeof (target->tgtstate));
+            if (strncmp (target->recov_status, "COMPLETE", 8) != 0)
+                memcpy (server->recov_status, target->recov_status,
+                        sizeof (target->recov_status));
+            /* Maintain target count in name field.
+             */
+            snprintf (server->name, sizeof (server->name), "(%d)",
+                      (int)strtoul (server->name + 1, NULL, 10) + 1);
+        } else {
+            server = (generic_target_t *) copy_fn ((void *) target);
+            snprintf (server->name, sizeof (server->name), "(%d)", 1);
+            list_append (server_data, server);
+        }
+    }
+    list_iterator_destroy (itr);
+}
+
+static void
+_single_mdt_update_summary (void *mdt_v, void *summary_v)
+{
+    mdtstat_t *mdt        = (mdtstat_t *) mdt_v;
+    mdtstat_t *summary    = (mdtstat_t *) summary_v;
+
+    sample_add (summary->open, mdt->open);
+    sample_add (summary->close, mdt->close);
+    sample_add (summary->getattr, mdt->getattr);
+    sample_add (summary->setattr, mdt->setattr);
+    sample_add (summary->link, mdt->link);
+    sample_add (summary->unlink, mdt->unlink);
+    sample_add (summary->mkdir, mdt->mkdir);
+    sample_add (summary->rmdir, mdt->rmdir);
+    sample_add (summary->statfs, mdt->statfs);
+    sample_add (summary->rename, mdt->rename);
+    sample_add (summary->getxattr, mdt->getxattr);
+
+    /* %cpu and %mem are per-server, and so the initial copy
+     * made by _copy_mdtstat() is correct for the summarized
+     * view with no further processing
+     */
+}
+
+/* Re-create mds_data, one record per mds, with data aggregated from
+ * the MDT's on that MDS.
+ */
+static void
+_summarize_mdt (List mdt_data, List mds_data, time_t tnow, int stale_secs)
+{
+    _summarize_target (mdt_data, mds_data, tnow, stale_secs,
+                       _single_mdt_update_summary, _copy_mdtstat,
+                       (ListFindF)  _match_mdtstat2);
+    list_sort (mds_data, (ListCmpF)_cmp_tgtstat_byserver);
+}
+
 /* Re-create oss_data, one record per oss, with data aggregated from
  * the OST's on that OSS.
  */
 static void
 _summarize_ost (List ost_data, List oss_data, time_t tnow, int stale_secs)
 {
-    oststat_t *o, *o2;
-    ListIterator itr;
-
-    _list_empty_out (oss_data);
-    itr = list_iterator_create (ost_data);
-    while ((o = list_next (itr))) {
-        if (tnow - o->ost_metric_timestamp > stale_secs)
-            continue;
-        o2 = list_find_first (oss_data, (ListFindF)_match_oststat2, o->ossname);
-        if (o2) {
-            sample_add (o2->rbytes, o->rbytes);
-            sample_add (o2->wbytes, o->wbytes);
-            sample_add (o2->iops, o->iops);
-            sample_add (o2->kbytes_free, o->kbytes_free);
-            sample_add (o2->kbytes_total, o->kbytes_total);
-            sample_add (o2->lock_count, o->lock_count);
-            sample_add (o2->grant_rate, o->grant_rate);
-            sample_add (o2->cancel_rate, o->cancel_rate);
-            sample_add (o2->connect, o->connect);
-            if (o->ost_metric_timestamp < o2->ost_metric_timestamp)
-                o2->ost_metric_timestamp = o->ost_metric_timestamp;
-            /* Ensure recov_status and oscstate reflect any unrecovered or
-             * non-full state of individual OSTs.  Last in wins.
-             */
-            if (strcmp (o->oscstate, "F") != 0)
-                memcpy (o2->oscstate, o->oscstate, sizeof (o->oscstate));
-            if (strncmp (o->recov_status, "COMPLETE", 8) != 0)
-                memcpy (o2->recov_status, o->recov_status,
-                        sizeof (o->recov_status));
-            /* Any "missing clients" on OST's should be reflected in OSS exp.
-             */
-            sample_min (o2->num_exports, o->num_exports);
-            /* Maintain OST count in name field.
-             */
-            snprintf (o2->name, sizeof (o2->name), "(%d)",
-                      (int)strtoul (o2->name + 1, NULL, 10) + 1);
-            if (o->tag)
-                o2->tag = o->tag;
-        } else {
-            o2 = _copy_oststat (o);
-            snprintf (o2->name, sizeof (o2->name), "(%d)", 1);
-            list_append (oss_data, o2);
-        }
-    }
-    list_iterator_destroy (itr);
-    list_sort (oss_data, (ListCmpF)_cmp_oststat_byoss);
+    _summarize_target (ost_data, oss_data, tnow, stale_secs,
+                       _single_ost_update_summary, _copy_oststat,
+                       (ListFindF)  _match_oststat2);
+    list_sort (oss_data, (ListCmpF)_cmp_tgtstat_byserver);
 }
 
-/* Clear all tags.
+/* Identify the record in c[] which should be used for
+ * sorting the list of targets.  k is the character
+ * entered by the user, sort_index identifies the
+ * record used previously, and c[] includes the key
+ * for each column along with a pointer to the appropriate
+ * comparison function.
+ * Logic for '<' and '>' assumes c[] is ordered appropriately.
  */
-static void
-_clear_tags (List ost_data)
+static int
+_get_sort_index (char k, int sort_index, sort_t c[], int nc)
 {
-    oststat_t *o;
-    ListIterator itr;
-
-    itr = list_iterator_create (ost_data);
-    while ((o = list_next (itr)))
-        o->tag = 0;
-    list_iterator_destroy (itr);
-}
-
-/* Set tag value on ost's with specified oss.
- */
-static void
-_tag_ost_byoss (List ost_data, char *ossname, int tagval)
-{
-    oststat_t *o;
-    ListIterator itr;
-
-    itr = list_iterator_create (ost_data);
-    while ((o = list_next (itr)))
-        if (!strcmp (o->ossname, ossname))
-            o->tag = tagval;
-    list_iterator_destroy (itr);
-}
-
-/* Toggle tag value on nth ost.
- * If tagging ost_data (first param), set the last paramter NULL.
- * If tagging oss_data (first param), set the last parmater to ost_data,
- * and all ost's on this oss will get tagged too.
- */
-static void
-_tag_nth_ost (List ost_data, int selost, List ost_data2)
-{
-    oststat_t *o;
-    ListIterator itr;
-    int n = 0;
-
-    itr = list_iterator_create (ost_data);
-    while ((o = list_next (itr))) {
-        if (selost == n++) {
-            o->tag = !o->tag;
-            break;
-        }
-    }
-    list_iterator_destroy (itr);
-    if (ost_data2 && o != NULL)
-        _tag_ost_byoss (ost_data2, o->ossname, o->tag);
-}
-
-typedef struct {
-    ListCmpF fun;
-    char k;
-} sort_t;
-
-/* Sort the list of OST's according to the specified key (k).
- */
-static void
-_sort_ostlist (List ost_data, time_t tnow, char k, int *ip)
-{
-    sort_t c[] = { /* order affects - see _update_display_ost () */
-        { .fun = (ListCmpF)_cmp_oststat_byost,   .k = 't' },
-        { .fun = (ListCmpF)_cmp_oststat_noop,    .k =  0  }, /* no-op */
-        { .fun = (ListCmpF)_cmp_oststat_byoss,   .k = 's' },
-        { .fun = (ListCmpF)_cmp_oststat_byexp,   .k = 'x' },
-        { .fun = (ListCmpF)_cmp_oststat_byconn,  .k = 'C' },
-        { .fun = (ListCmpF)_cmp_oststat_byrbw,   .k = 'r' },
-        { .fun = (ListCmpF)_cmp_oststat_bywbw,   .k = 'w' },
-        { .fun = (ListCmpF)_cmp_oststat_byiops,  .k = 'i' },
-        { .fun = (ListCmpF)_cmp_oststat_bylocks, .k = 'l' },
-        { .fun = (ListCmpF)_cmp_oststat_bylgr,   .k = 'g' },
-        { .fun = (ListCmpF)_cmp_oststat_bylcr,   .k = 'L' },
-        { .fun = (ListCmpF)_cmp_oststat_bycpu,   .k = 'u' },
-        { .fun = (ListCmpF)_cmp_oststat_bymem,   .k = 'm' },
-        { .fun = (ListCmpF)_cmp_oststat_byspc,   .k = 'S' },
-    };
-    int i = *ip, j, nc = sizeof (c) / sizeof (c[0]);
+    int j;
 
     if (k == '<') {
-        if (--i < 0)
-            i = nc - 1;
+        if (--sort_index < 0)
+            sort_index = nc - 1;
     } else if (k == '>') {
-        if (++i == nc)
-            i = 0;
+        if (++sort_index == nc)
+            sort_index = 0;
     } else if (k != 0) {
         for (j = 0; j < nc; j++) {
             if (c[j].k == k) {
-                i = j;
+                sort_index = j;
                 break;
             }
         }
     }
-    assert (i >= 0 && i < nc);
- 
+    assert (sort_index >= 0 && sort_index < nc);
+    return sort_index;
+}
+
+/* Sort the list of MDT's using the specified comparison function.
+ * tnow required for comparisons that operate on samples.
+ */
+static void
+_sort_tgtlist (List tgt_data, time_t tnow, ListCmpF comparison_function)
+{
     sort_tnow = tnow;
-    list_sort (ost_data, c[i].fun);
-    *ip = i;
+    list_sort (tgt_data, comparison_function);
 }
 
 /* Helper for _list_empty_out ().
@@ -1903,6 +2345,60 @@ _list_empty_out (List l)
 {
     list_delete_all (l, (ListFindF)_list_find_all, NULL);
 }
+
+/* Clear all tags.
+ */
+static void
+_clear_tags (List ost_data)
+{
+    oststat_t *o;
+    ListIterator itr;
+
+    itr = list_iterator_create (ost_data);
+    while ((o = list_next (itr)))
+        o->common.tag = 0;
+    list_iterator_destroy (itr);
+}
+
+/* Set tag value on ost's with specified oss.
+ */
+static void
+_tag_ost_byoss (List ost_data, char *ossname, int tagval)
+{
+    oststat_t *o;
+    ListIterator itr;
+
+    itr = list_iterator_create (ost_data);
+    while ((o = list_next (itr)))
+        if (!strcmp (o->ossname, ossname))
+            o->common.tag = tagval;
+    list_iterator_destroy (itr);
+}
+
+/* Toggle tag value on nth ost.
+ * If tagging ost_data (first param), set the last paramter NULL.
+ * If tagging oss_data (first param), set the last parmater to ost_data,
+ * and all ost's on this oss will get tagged too.
+ */
+static void
+_tag_nth_ost (List ost_data, int selost, List ost_data2)
+{
+    oststat_t *o;
+    ListIterator itr;
+    int n = 0;
+
+    itr = list_iterator_create (ost_data);
+    while ((o = list_next (itr))) {
+        if (selost == n++) {
+            o->common.tag = !o->common.tag;
+            break;
+        }
+    }
+    list_iterator_destroy (itr);
+    if (ost_data2 && o != NULL)
+        _tag_ost_byoss (ost_data2, o->ossname, o->common.tag);
+}
+
 
 /*
  * vi:tabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Three commits:
* Fix an overflow while copying a string containing recovery status.  The recovery status is copied from the lmt_mdt message into a local string, while looping over the MDTs.  The code contained an incorrect calculation of the maximum allowable length, so the strncpy or equivalent call could overflow the destination buffer.
* Fix a compile warning about an uninitialized variable, by initializing it during declaration.

* Create a separate sub-window listing each MDT, in addition to the existing one listing each OST.  Allow for sorting, collapsing MDTs to MDSs, like the existing OST window.
