### PR TITLE
libproc: look in /sys and /proc as necessary

### DIFF
--- a/cerebro/metric/mdt.c
+++ b/cerebro/metric/mdt.c
@@ -65,7 +65,7 @@ _get_metric_value (unsigned int *metric_value_type,
                    unsigned int *metric_value_len,
                    void **metric_value)
 {
-    pctx_t ctx = proc_create ("/proc");
+    pctx_t ctx = proc_create ("/");
     char *buf = xmalloc (CEREBRO_MAX_DATA_STRING_LEN);
     int retval = -1;
 

--- a/cerebro/metric/osc.c
+++ b/cerebro/metric/osc.c
@@ -65,7 +65,7 @@ _get_metric_value (unsigned int *metric_value_type,
                    unsigned int *metric_value_len,
                    void **metric_value)
 {
-    pctx_t ctx = proc_create ("/proc");
+    pctx_t ctx = proc_create ("/");
     char *buf = xmalloc (CEREBRO_MAX_DATA_STRING_LEN);
     int retval = -1;
 

--- a/cerebro/metric/ost.c
+++ b/cerebro/metric/ost.c
@@ -65,7 +65,7 @@ _get_metric_value (unsigned int *metric_value_type,
                    unsigned int *metric_value_len,
                    void **metric_value)
 {
-    pctx_t ctx = proc_create ("/proc");
+    pctx_t ctx = proc_create ("/");
     char *buf = xmalloc (CEREBRO_MAX_DATA_STRING_LEN);
     int retval = -1;
 

--- a/cerebro/metric/router.c
+++ b/cerebro/metric/router.c
@@ -65,7 +65,7 @@ _get_metric_value (unsigned int *metric_value_type,
                    unsigned int *metric_value_len,
                    void **metric_value)
 {
-    pctx_t ctx = proc_create ("/proc");
+    pctx_t ctx = proc_create ("/");
     char *buf = xmalloc (CEREBRO_MAX_DATA_STRING_LEN);
     int retval = -1;
 

--- a/libproc/lustre.c
+++ b/libproc/lustre.c
@@ -217,7 +217,7 @@ _packed_lustre_version (pctx_t ctx)
     ret = proc_fs_lustre_version(ctx, &major, &minor, &patch, &fix);
 
     if (ret < 0) {
-        ctx_sys = proc_create("/sys");
+        ctx_sys = proc_create("/");
         if (!ctx_sys)
             return -1;
 

--- a/test/t10-metric-strings
+++ b/test/t10-metric-strings
@@ -28,7 +28,7 @@ test_metrics() {
     while read line; do
         ref_string="$(eval echo "\"$line\"")"
         m_name=$(echo $ref_string | cut -f1 -d:)
-        tst_string=$(../utils/lmtmetric -r $path/proc -m $m_name)
+        tst_string=$(../utils/lmtmetric -r $path/ -m $m_name)
         echo $tst_string >> $out_file
         if [ "$ref_string" != "$tst_string" ]; then
             echo $ref_string >> $ref_file

--- a/test/test_header
+++ b/test/test_header
@@ -5,7 +5,7 @@ test_versions() {
 
     for path in lustre_versions/*; do
         version=$(basename $path)
-        $test_bin $path/proc >$TEST-$version.out 2>&1
+        $test_bin $path/ >$TEST-$version.out 2>&1
 
         if diff $path/outputs/$TEST.exp \
                 $TEST-$version.out >$TEST-$version.diff; then

--- a/utils/lmtmetric.c
+++ b/utils/lmtmetric.c
@@ -78,7 +78,7 @@ usage()
     fprintf (stderr,
 "Usage: lmtmetric [OPTIONS]\n"
 "   -m,--metric NAME            select ost|mdt|osc|router|sysstat\n"
-"   -r,--proc-root DIR          select proc root other than /proc\n"
+"   -r,--root DIR               select root for (sys,proc) other than /\n"
 "   -t,--update-period SECS     [default: run once]\n"
     );
     exit (1);
@@ -89,7 +89,7 @@ main (int argc, char *argv[])
 {
     pctx_t ctx;
     char buf[CEREBRO_MAX_DATA_STRING_LEN];
-    char *proc_root = "/proc";
+    char *proc_root = "/";
     char *metric = NULL;
     unsigned long update_period = 0;
     int c, n = 0;


### PR DESCRIPTION
Rather than always looking under /proc for a given subdirectory,
look under /sys and then if that is not found, look under /proc.
Use whichever path is found first.

This was done to allow lmt to find Lustre 2.12 metrics, some of
which were moved to /sys, but with the path under /sys the same
as the old path under /proc.

With this patch there are some additional stat() calls, so the metric
does slightly more I/O than was required previously.  However since
these are stats of /proc or /sys files, they should be cheap.  In
return we have much less lustre-version specific code to handle this
transition in the lustre codebase.