### PR TITLE
Space and Inodes for MDTs show in ltop

### DIFF
--- a/liblmtdb/lmtdb.c
+++ b/liblmtdb/lmtdb.c
@@ -276,20 +276,6 @@ done:
         list_destroy (mdops);
 }
 
-/* lmt_mdt_v1: mds + multipe mdt's */
-void
-lmt_db_insert_mdt_v1 (char *s)
-{
-    lmt_db_insert_mdt_v1_v2 (s, 1);
-}
-
-/* lmt_mdt_v2: mds + multipe mdt's w/ recovery info */
-void
-lmt_db_insert_mdt_v2 (char *s)
-{
-    lmt_db_insert_mdt_v1_v2 (s, 2);
-}
-
 /* lmt_mdt_v1 and lmt_mdt_v2 helper */
 void
 lmt_db_insert_mdt_v1_v2 (char *s, int ver)
@@ -312,6 +298,20 @@ done:
         free (mdsname);    
     if (mdtinfo)
         list_destroy (mdtinfo);
+}
+
+/* lmt_mdt_v1: mds + multipe mdt's */
+void
+lmt_db_insert_mdt_v1 (char *s)
+{
+    lmt_db_insert_mdt_v1_v2 (s, 1);
+}
+
+/* lmt_mdt_v2: mds + multipe mdt's w/ recovery info */
+void
+lmt_db_insert_mdt_v2 (char *s)
+{
+    lmt_db_insert_mdt_v1_v2 (s, 2);
 }
 
 /* lmt_router_v1: router */


### PR DESCRIPTION
Space free and total space metrics are reported for MDTs like they are
for OSTs.  Include them in the display provided by ltop.

Originally written as part of a larger patch by Phil Eckert.  Semantic
changes factored out by Olaf Faaland.

This increases the window width from 80 to 90 characters.

Closes #34