### PR TITLE
Recovery status reported for any status other than COMPLETE

### DIFF
--- a/utils/ltop.c
+++ b/utils/ltop.c
@@ -883,7 +883,9 @@ _update_display_top (WINDOW *win, char *fs, List ost_data, List mdt_data,
          * recovery_status is just a string, and has no timestamp.
          */
         if ((tnow - m->common.tgt_metric_timestamp) < stale_secs) {
-            if (m->common.recov_status && strstr(m->common.recov_status,"RECOV")) {
+            if (m->common.recov_status  &&
+                !strstr(m->common.recov_status,"COMPLETE") &&
+                !strstr(m->common.recov_status,"INACTIVE")) {
                 /*
                  * Multiple MDTs may be in recovery, but display room
                  * is limited.  We print the full status of the first
@@ -1182,8 +1184,8 @@ _update_display_mdt (WINDOW *win, int line, void *target, int stale_secs,
         // available info is expired 
         mvwprintw (win, line, 0, "%4.4s data is stale", m->common.name);
     } else if (m->common.recov_status &&
-               strstr(m->common.recov_status,"RECOV")) {
-        /* mdt is in recovery - display recovery stats */
+               !strstr(m->common.recov_status,"COMPLETE")) {
+        /* mdt is in recovery or not running - display recovery stats */
         mvwprintw (win, line, 0, "%4.4s   %10.10s %s",
                    m->common.name, _ltrunc (m->common.servername, 10),
                    m->common.recov_status);
@@ -1223,13 +1225,12 @@ _update_display_ost (WINDOW *win, int line, void *target, int stale_secs,
         mvwprintw (win, line, 0, "%4.4s %1.1s data is stale",
                    o->common.name, o->common.tgtstate);
     /* ost is in recovery - display recovery stats */
-    } else if (strncmp (o->common.recov_status, "COMPLETE", 8) != 0
-            && strncmp (o->common.recov_status, "INACTIVE", 8) != 0) {
+    } else if (strncmp (o->common.recov_status, "COMPLETE", 8) != 0) {
         mvwprintw (win, line, 0, "%4.4s %1.1s %10.10s   %s",
                    o->common.name, o->common.tgtstate,
                    _ltrunc (o->common.servername, 10),
                    o->common.recov_status);
-    /* ost is not in recover (state == INACTIVE|COMPLETE) */
+    /* ost is not in running (state == COMPLETE) */
     } else {
         mvwprintw (win, line, 0, "%4.4s %1.1s %10.10s"
                    " %5.0f %4.0f %5.0f %5.0f %5.0f %7.0f %4.0f %4.0f"


### PR DESCRIPTION
In a multi-MDT system, under Lustre 2.10, all MDTs connect to each other via exports/imports.  If one MDT cannot connect to one or more other MDTs, it will not service requests and will refuse connections from clients.  There are other target states which may indicate action is required by an admin.  These states are reflected in the "recovery_status" procfile exported by Lustre targets.

However, for LMT 3.2.7 and some releases before that, MDTs in such a state were not reported as such in ltop, because ltop checked for "RECOV" in the status field, indicting recovery, but did not check for the strings corresponding to any other states.

According lprocfs_recovery_status_seq_show() in Lustre 2.13,
valid "status" values in recovery_status are (roughly):
```
COMPLETE             The target is active and handling requests
WAITING              The target is active but waiting for another MDT
WAITING_FOR_CLIENTS  The target is active but no clients have connected
RECOVERY             The target is active and recovering after failover
INACTIVE             The target is inactive
```

For individual targets, for all states other than COMPLETE, display the
recov_status field instead of metric values.   This makes it easier for
the admin to see unhealthy targets.

At the top of the window, report the lowest-numbered MDT which is not
COMPLETE or INACTIVE.  If an MDT is INACTIVE, it was set that way by
an admin and she likely already knows - but other states may not be
expected and should be brought to her attention.