### PR TITLE
quote call to AC_LANG_CALL

### DIFF
--- a/config/x_ac_check_cond_lib.m4
+++ b/config/x_ac_check_cond_lib.m4
@@ -25,7 +25,7 @@ AC_DEFUN([X_AC_CHECK_COND_LIB], [
     [for $2 in default libs],
     [x_ac_cv_lib_none_$2], [
     AC_LINK_IFELSE(
-      AC_LANG_CALL([], [$2]),
+      [AC_LANG_CALL([], [$2])],
       AS_VAR_SET(x_ac_cv_lib_none_$2, yes),
       AS_VAR_SET(x_ac_cv_lib_none_$2, no)
     )]


### PR DESCRIPTION
Quote a call to AC_LANG_CALL in config/x_ac_check_cond_lib.m4 to quiet
an automake warning.

If a call to AC_LANG_SOURCE is not quoted, and the output includes
commas, any outer IFELSE will see the wrong set of arguments and
produce undesired results.

AC_LANG_{PROGRAM,CALL} are implemented using AC_LANG_SOURCE, so the
same issues applies to them.

Newer versions of automake (automake-1.13.4-3.el7 at least) emit
warnings like these if un-quoted calls are detected:

configure.ac:60: warning: AC_LANG_CONFTEST: no AC_LANG_SOURCE call
detected in body
../../lib/autoconf/lang.m4:193: AC_LANG_CONFTEST is expanded from...
../../lib/autoconf/general.m4:2661: _AC_LINK_IFELSE is expanded from...
../../lib/autoconf/general.m4:2678: AC_LINK_IFELSE is expanded from...
../../lib/m4sugar/m4sh.m4:639: AS_IF is expanded from...
../../lib/autoconf/general.m4:2031: AC_CACHE_VAL is expanded from...
../../lib/autoconf/general.m4:2052: AC_CACHE_CHECK is expanded from...
config/x_ac_check_cond_lib.m4:23: X_AC_CHECK_COND_LIB is expanded
from...
configure.ac:60: the top level
[snip]

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>