### PR TITLE
follow symlinks under /proc

### DIFF
--- a/libproc/proc.c
+++ b/libproc/proc.c
@@ -249,7 +249,7 @@ proc_readdir (pctx_t ctx, proc_readdir_flag_t flag, char **namep)
             continue;
         if ((flag & PROC_READDIR_NODIR) && d->d_type == DT_DIR)
             continue;
-        if ((flag & PROC_READDIR_NOFILE) && d->d_type != DT_DIR)
+        if ((flag & PROC_READDIR_NOFILE) && d->d_type != DT_DIR && d->d_type != DT_LNK)
             continue;
         if (!(name = strdup (d->d_name)))
             msg_exit ("out of memory");


### PR DESCRIPTION
Under Lustre 2.8 and 2.10 at least, /proc/fs/lustre/osc contains
links to objects in /proc/fs/lustre/osc.  Prior to Lustre 2.4 at
least, there were subdirectories there.  The lmt code for
reading /proc directories, proc_readdir(), takes a flag to indicate
whether files or subdirectories are being searched for.

If the flag for finding subdirectories, PROC_READDIR_NOFILE, is
passed, symlinks should be not be skipped as they may point to
subdirectories.

Credit to @6speedlt1 on github for identifying the fix.

Fixes #30.