### PR TITLE
recursively eval in config/x_ac_expand_install_dirs.m4

### DIFF
--- a/config/ax_recursive_eval.m4
+++ b/config/ax_recursive_eval.m4
@@ -1,0 +1,56 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_recursive_eval.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_RECURSIVE_EVAL(VALUE, RESULT)
+#
+# DESCRIPTION
+#
+#   Interpolate the VALUE in loop until it doesn't change, and set the
+#   result to $RESULT. WARNING: It's easy to get an infinite loop with some
+#   unsane input.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Alexandre Duret-Lutz <adl@gnu.org>
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 1
+
+AC_DEFUN([AX_RECURSIVE_EVAL],
+[_lcl_receval="$1"
+$2=`(test "x$prefix" = xNONE && prefix="$ac_default_prefix"
+     test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+     _lcl_receval_old=''
+     while test "[$]_lcl_receval_old" != "[$]_lcl_receval"; do
+       _lcl_receval_old="[$]_lcl_receval"
+       eval _lcl_receval="\"[$]_lcl_receval\""
+     done
+     echo "[$]_lcl_receval")`])

--- a/config/x_ac_expand_install_dirs.m4
+++ b/config/x_ac_expand_install_dirs.m4
@@ -19,72 +19,72 @@ AC_DEFUN([X_AC_EXPAND_INSTALL_DIRS], [
   _x_ac_expand_install_dirs_exec_prefix="$exec_prefix"
   test "$exec_prefix" = NONE && exec_prefix="$prefix"
 
-  eval X_PREFIX="$prefix"
+  AX_RECURSIVE_EVAL(["$prefix"], [X_PREFIX])
   AC_DEFINE_UNQUOTED([X_PREFIX], ["$X_PREFIX"],
     [Expansion of the "prefix" installation directory.])
   AC_SUBST([X_PREFIX])
 
-  eval X_EXEC_PREFIX="$exec_prefix"
+  AX_RECURSIVE_EVAL(["$exec_prefix"], [X_EXEC_PREFIX])
   AC_DEFINE_UNQUOTED([X_EXEC_PREFIX], ["$X_EXEC_PREFIX"],
     [Expansion of the "exec_prefix" installation directory.])
   AC_SUBST([X_EXEC_PREFIX])
 
-  eval X_BINDIR="$bindir"
+  AX_RECURSIVE_EVAL(["$bindir"], [X_BINDIR])
   AC_DEFINE_UNQUOTED([X_BINDIR], ["$X_BINDIR"],
     [Expansion of the "bindir" installation directory.])
   AC_SUBST([X_BINDIR])
 
-  eval X_SBINDIR="$sbindir"
+  AX_RECURSIVE_EVAL(["$sbindir"], [X_SBINDIR])
   AC_DEFINE_UNQUOTED([X_SBINDIR], ["$X_SBINDIR"],
     [Expansion of the "sbindir" installation directory.])
   AC_SUBST([X_SBINDIR])
 
-  eval X_LIBEXECDIR="$libexecdir"
+  AX_RECURSIVE_EVAL(["$libexecdir"], [X_LIBEXECDIR])
   AC_DEFINE_UNQUOTED([X_LIBEXECDIR], ["$X_LIBEXECDIR"],
     [Expansion of the "libexecdir" installation directory.])
   AC_SUBST([X_LIBEXECDIR])
 
-  eval X_DATADIR="$datadir"
+  AX_RECURSIVE_EVAL(["$datadir"], [X_DATADIR])
   AC_DEFINE_UNQUOTED([X_DATADIR], ["$X_DATADIR"],
     [Expansion of the "datadir" installation directory.])
   AC_SUBST([X_DATADIR])
 
-  eval X_SYSCONFDIR="$sysconfdir"
+  AX_RECURSIVE_EVAL(["$sysconfdir"], [X_SYSCONFDIR])
   AC_DEFINE_UNQUOTED([X_SYSCONFDIR], ["$X_SYSCONFDIR"],
     [Expansion of the "sysconfdir" installation directory.])
   AC_SUBST([X_SYSCONFDIR])
 
-  eval X_SHAREDSTATEDIR="$sharedstatedir"
+  AX_RECURSIVE_EVAL(["$sharedstatedir"], [X_SHAREDSTATEDIR])
   AC_DEFINE_UNQUOTED([X_SHAREDSTATEDIR], ["$X_SHAREDSTATEDIR"],
     [Expansion of the "sharedstatedir" installation directory.])
   AC_SUBST([X_SHAREDSTATEDIR])
 
-  eval X_LOCALSTATEDIR="$localstatedir"
+  AX_RECURSIVE_EVAL(["$localstatedir"], [X_LOCALSTATEDIR])
   AC_DEFINE_UNQUOTED([X_LOCALSTATEDIR], ["$X_LOCALSTATEDIR"],
     [Expansion of the "localstatedir" installation directory.])
   AC_SUBST([X_LOCALSTATEDIR])
 
-  eval X_LIBDIR="$libdir"
+  AX_RECURSIVE_EVAL(["$libdir"], [X_LIBDIR])
   AC_DEFINE_UNQUOTED([X_LIBDIR], ["$X_LIBDIR"],
     [Expansion of the "libdir" installation directory.])
   AC_SUBST([X_LIBDIR])
 
-  eval X_INCLUDEDIR="$includedir"
+  AX_RECURSIVE_EVAL(["$includedir"], [X_INCLUDEDIR])
   AC_DEFINE_UNQUOTED([X_INCLUDEDIR], ["$X_INCLUDEDIR"],
     [Expansion of the "includedir" installation directory.])
   AC_SUBST([X_INCLUDEDIR])
 
-  eval X_OLDINCLUDEDIR="$oldincludedir"
+  AX_RECURSIVE_EVAL(["$oldincludedir"], [X_OLDINCLUDEDIR])
   AC_DEFINE_UNQUOTED([X_OLDINCLUDEDIR], ["$X_OLDINCLUDEDIR"],
     [Expansion of the "oldincludedir" installation directory.])
   AC_SUBST([X_OLDINCLUDEDIR])
 
-  eval X_INFODIR="$infodir"
+  AX_RECURSIVE_EVAL(["$infodir"], [X_INFODIR])
   AC_DEFINE_UNQUOTED([X_INFODIR], ["$X_INFODIR"],
     [Expansion of the "infodir" installation directory.])
   AC_SUBST([X_INFODIR])
 
-  eval X_MANDIR="$mandir"
+  AX_RECURSIVE_EVAL(["$mandir"], [X_MANDIR])
   AC_DEFINE_UNQUOTED([X_MANDIR], ["$X_MANDIR"],
     [Expansion of the "mandir" installation directory.])
   AC_SUBST([X_MANDIR])


### PR DESCRIPTION
${prefix} is left unexpanded in some path defines processed by
config/x_ac_expand_install_dirs.m4.  Some macros then include the
literal string "${prefix}" in their values as reflected in
config/config.h.

  #define X_DATADIR "${prefix}/share"
  #define X_INFODIR "${prefix}/share/info"
  #define X_MANDIR "${prefix}/share/man"

Add adl_RECURSIVE_EVAL() and use it to recursively evaluate the macros
in config/x_ac_expand_install_dirs.m4.

Fixes #44