### PR TITLE
Fix lustre version parsing

### DIFF
--- a/libproc/lustre.c
+++ b/libproc/lustre.c
@@ -193,6 +193,9 @@ _find_mdt_dir (pctx_t ctx)
 {
     int lustre_version = _packed_lustre_version (ctx);
 
+    if (lustre_version == -1)
+        msg_exit ("failed to determine lustre version");
+
     /* Keep adding to the top of this as changes accrue */
     if (lustre_version >= LUSTRE_2_0)
        return PROC_FS_LUSTRE_2_0_MDT_DIR;
@@ -1033,19 +1036,36 @@ _read_lustre_version_string(pctx_t ctx, char **version_string)
     rh = hash_create (STATS_HASH_SIZE, (hash_key_f)hash_key_string,
                       (hash_cmp_f)strcmp, (hash_del_f)_destroy_shash);
 
+    /*
+     * For Lustre <= 2.8 version file was 3-record key-value format.
+     * Afterwards it was just a bare version string.
+     */
     ret = _hash_stats (ctx, rh);
-
     proc_close (ctx);
 
-    if (!(version = hash_find (rh, "lustre:"))) {
-        ret = -1;
-        goto done;
+    if (hash_count(rh) > 0) {
+        if (!(version = hash_find (rh, "lustre:"))) {
+            ret = -1;
+            goto done;
+        }
+
+        if (!(*version_string = strdup(version->val)))
+            msg_exit ("out of memeory");
+        ret = 0;
+
+    } else {
+        char buf[64];
+        int rc;
+
+        rc = proc_gets (ctx, PROC_FS_LUSTRE_VERSION, buf, sizeof(buf));
+        if (rc < 0) {
+            msg_exit ("Unable to read version string");
+        }
+        if (!(*version_string = strdup(buf)))
+            msg_exit ("out of memory");
+        ret = 0;
     }
 
-    if (!(*version_string = strdup(version->val)))
-        msg_exit ("out of memeory");
-
-    ret = 0;
 done:
     if (rh)
         hash_destroy(rh);

--- a/libproc/lustre.c
+++ b/libproc/lustre.c
@@ -133,45 +133,6 @@ typedef enum {
 
 /*
  * Fill-in the supplied version components with the Lustre version
- * found in /sys.
- *
- * Returns -1 on error, 0 or greater on success.
- */
-int
-sys_fs_lustre_version (pctx_t ctx, int *major, int *minor, int *patch,
-                       int *fix)
-{
-    int ret;
-    char version[256];
-
-    if ((ret = proc_openf (ctx, PROC_FS_LUSTRE_VERSION)) < 0)
-        goto done;
-
-    if ((ret = proc_gets (ctx, NULL, version, sizeof (version))) < 0)
-        goto close;
-
-    /* first, get the numbers which must be present in a version string */
-    if ((ret = sscanf (version, "%d.%d.%d", major, minor, patch)) != 3) {
-        errno = EINVAL;
-        ret = -1;
-        goto close;
-    }
-
-    /* now, get the optional fix value or set it to 0 */
-    if (sscanf (version, "%*d.%*d.%*d.%d", fix) != 1)
-        *fix = 0;
-
-close:
-    proc_close (ctx);
-done:
-    if (ret < 0)
-        ret = -1;
-
-    return ret;
-}
-
-/*
- * Fill-in the supplied version components with the Lustre version
  * found in /proc.
  *
  * Returns -1 or less on error, 0 or greater on success.
@@ -212,23 +173,13 @@ _packed_lustre_version (pctx_t ctx)
 {
     int ret = -1;
     int major = 0, minor = 0, patch = 0, fix = 0;
-    pctx_t ctx_sys;
 
-    ret = proc_fs_lustre_version(ctx, &major, &minor, &patch, &fix);
+    if ((ret = proc_fs_lustre_version (ctx, &major, &minor, &patch, &fix)) < 0)
+        goto done;
 
-    if (ret < 0) {
-        ctx_sys = proc_create("/");
-        if (!ctx_sys)
-            return -1;
-
-        ret = sys_fs_lustre_version (ctx_sys, &major, &minor, &patch, &fix);
-        proc_destroy(ctx_sys);
-    }
-
-    if (ret < 0)
-        return -1;
-
-    return PACKED_VERSION (major, minor, patch, fix);
+    ret = PACKED_VERSION(major, minor, patch, fix);
+done:
+    return ret;
 }
 
 /*


### PR DESCRIPTION
These two commits re-work how lmt handles differences in the location and contents of the Lustre version file for Lustre <= 2.8 vs. > 2.8.

The first commit reverts 
* 8a2a19c Add /sys in Lustre version checking (#31)
which causes lmt to always look in the real /proc or /sys to find the lustre version, which ultimately breaks the compatability tests performed via "make check".

The second commit alters _read_lustre_version_string() to correctly handle the contents of the Lustre version file after v 2.8 (a bare version string) as well as up to v 2.8 (3 rows in key-value format).

Testing:
Tested by hand with "make check", running utils/ltop on a cluster running lmt-3.2.6 and another one running lmt-3.2.7,  and running lmtmetric on an MDS and OSS on lustre servers running lustre 2.10.8.

Fixes #49 